### PR TITLE
画像をS3に保存する設定

### DIFF
--- a/app/uploaders/icon_uploader.rb
+++ b/app/uploaders/icon_uploader.rb
@@ -6,8 +6,11 @@ class IconUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,10 +3,10 @@
 if Rails.env.production?
   CarrierWave.configure do |config|
     config.fog_credentials = {
-      :provider => 'AWS',
-      :region => ENV['S3_REGION'],
-      :aws_access_key_id => ENV['S3_ACCESS_KEY'],
-      :aws_secret_access_key => ENV['S3_SECRET_KEY'],
+      provider: 'AWS',
+      region: ENV['S3_REGION'],
+      aws_access_key_id: ENV['S3_ACCESS_KEY'],
+      aws_secret_access_key: ENV['S3_SECRET_KEY'],
     }
     config.fog_directionary = ENV['S3_BUCKET']
   end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
-CarrierWave.configure do |config|
-  config.asset_host = ENV['BACKEND_ORIGIN']
+if Rails.env.production?
+  CarrierWave.configure do |config|
+    config.fog_credentials = {
+      :provider => 'AWS',
+      :region => ENV['S3_REGION'],
+      :aws_access_key_id => ENV['S3_ACCESS_KEY'],
+      :aws_secret_access_key => ENV['S3_SECRET_KEY'],
+    }
+    config.fog_directionary = ENV['S3_BUCKET']
+  end
+else
+  CarrierWave.configure do |config|
+    config.asset_host = ENV['BACKEND_ORIGIN']
+  end
 end


### PR DESCRIPTION
### 関連issue
#80

### やったこと
- IAMユーザーの作成 作成したIAMユーザーにS3へのアクセス権限を与える
- IAMユーザーのアクセスキーとシークレットキーをメモ
- S3バケット作成
- 画像をS3に保存するように設定

### 備考
- Herokuの環境変数の設定を行う

### 参考
- [Railsでcarrierwaveを使ってAWS S3に画像をアップロードする手順を画像付きで説明する](https://qiita.com/junara/items/1899f23c091bcee3b058)
