### PR TITLE
コメントの保存

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CommentsController < ApplicationController
+      before_action :require_login
+
+      def create
+        comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))
+        if comment.save
+          render status: :created, json: comment
+        else
+          render status: :bad_request, json: comment.errors
+        end
+      end
+
+      private
+
+      def comment_params
+        params.require(:comment).permit(:content)
+      end
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  validates :content, presence: true, length: { maximum: 1000 }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@
 
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :comments, dependent: :destroy
   validates :app_name, presence: true, length: { maximum: 50 }
   validates :app_url, presence: true, length: { maximum: 255 }
   validates :repo_url, length: { maximum: 255 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
   validates :name, { presence: true, length: { minimum: 3, maximum: 20 } }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   validates :email, {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
           delete :logout
         end
       end
-      resources :posts
+      resources :posts do
+        resources :comments, only: [:create]
+      end
     end
   end
 

--- a/db/migrate/20211108075756_create_comments.rb
+++ b/db/migrate/20211108075756_create_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateComments < ActiveRecord::Migration[6.1]
   def change
     create_table :comments do |t|

--- a/db/migrate/20211108075756_create_comments.rb
+++ b/db/migrate/20211108075756_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.string :content, null: false
+      t.references :user, foreign_key: true, null: false
+      t.references :post, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_25_060522) do
+ActiveRecord::Schema.define(version: 2021_11_08_075756) do
+
+  create_table "comments", force: :cascade do |t|
+    t.string "content", null: false
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -33,5 +43,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_060522) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
### 関連issue
#81 

### やったこと
- commentsテーブルの作成
  contentカラム(コメントの内容), user_idカラム(コメントしたユーザーのid), post_idカラム(コメント対象の投稿のid)を持たせた
- Commentモデルの作成
  コメントしたユーザーまたはコメント対象の投稿が削除されると、コメントも自動で削除されるように設定
- POST `/posts/:post_id/comments` の実装
  とりあえずコメントの作成のみ実装

### 動作確認
<img width="500" alt="スクリーンショット 2021-11-08 18 29 35" src="https://user-images.githubusercontent.com/61813626/140717341-3d9483e4-1168-4bc3-8d5f-cae6557ffaa1.png">

### 備考
Postmanを使い始めた 便利

### 参考
- [Railsでコメント機能をつくってみよう](https://qiita.com/nojinoji/items/2034764897c6e91ef982)
- [RailsのRoutingネストについて](https://qiita.com/keisukegdk/items/beb5a62c17278c25c00d)
- [PostmanでCookieが必要なAPIを実行する](https://tech.unifa-e.com/entry/2021/05/10/083532)
- [Postmanを使ってAPIの確認をしてみる](https://qiita.com/me-654393/items/b14824dd9b37de0da163)
