### PR TITLE
コメント追加とコメントの一覧表示

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -16,7 +16,11 @@ module Api
 
       def show
         post = Post.find(params[:id])
-        render staus: :ok, json: { post: post, user: post.user }
+        comments_and_users = []
+        post.comments.includes(:user).each do |comment|
+          comments_and_users.push({ comment: comment, user: comment.user })
+        end
+        render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }
       end
 
       def create

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -18,7 +18,7 @@ module Api
         post = Post.find(params[:id])
         comments_and_users = []
         post.comments.includes(:user).each do |comment|
-          comments_and_users.push({ comment: comment, user: comment.user })
+          comments_and_users.push({ comment: comment, user_name: comment.user.name, user_icon_url: comment.user.icon.url })
         end
         render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }
       end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -18,7 +18,7 @@ module Api
         if current_user.nil?
           render status: :ok, json: { logged_in: false }
         else
-          render status: :ok, json: { logged_in: true, user_name: current_user.name }
+          render status: :ok, json: { logged_in: true, user_name: current_user.name, user_icon_url: current_user.icon.url }
         end
       end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,3 +17,7 @@ end
 (1..10).each do |i|
   FactoryBot.create(:post, user_id: ((i - 1) / 2) + 1)
 end
+
+(1..20).each do |i|
+  FactoryBot.create(:comment, user_id: ((i - 1) % 5) + 1, post_id: ((i - 1) / 2) + 1)
+end

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1920,6 +1920,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.12.3",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -43,10 +43,17 @@ const CommentForm = (props) => {
               options={markdownOption}
             />
             <Grid container alignItems='center' justifyContent='center'>
-              <Button variant='contained' color='primary' style={{marginRight: 50}} onClick={submitComment}>
-                <SendIcon />
-                送信
-              </Button>
+              {markdown.length > 0 ?
+                <Button variant='contained' color='primary' style={{marginRight: 50}} onClick={submitComment}>
+                  <SendIcon />
+                  送信
+                </Button>
+                :
+                <Button variant='contained' disabled style={{marginRight: 50}} onClick={submitComment}>
+                  <SendIcon />
+                  送信
+                </Button>
+              }
               <Button
                 variant='contained'
                 color='secondary'

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -9,7 +9,7 @@ import SendIcon from '@material-ui/icons/Send';
 import CloseIcon from '@material-ui/icons/Close';
 import CreateIcon from '@material-ui/icons/Create';
 
-const CommentForm = () => {
+const CommentForm = (props) => {
   const [formOpen, setFormOpen] = useState(false);
   const userName = useContext(AuthContext).userName;
   const userIconUrl = useContext(AuthContext).userIconUrl;
@@ -20,6 +20,12 @@ const CommentForm = () => {
       spellChecker: false,
     };
   }, []);
+
+  const submitComment = () => {
+    props.submitComment(markdown);
+    setMarkdown('');
+    setFormOpen(false);
+  };
 
   return (
     <Grid container alignItems='center' justifyContent='center'>
@@ -37,7 +43,7 @@ const CommentForm = () => {
               options={markdownOption}
             />
             <Grid container alignItems='center' justifyContent='center'>
-              <Button variant='contained' color='primary' style={{marginRight: 50}}>
+              <Button variant='contained' color='primary' style={{marginRight: 50}} onClick={submitComment}>
                 <SendIcon />
                 送信
               </Button>

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -1,0 +1,67 @@
+import React, { useState, useMemo, useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+import Owner from './Owner';
+import SimpleMDE from 'react-simplemde-editor';
+import 'easymde/dist/easymde.min.css';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import SendIcon from '@material-ui/icons/Send';
+import CloseIcon from '@material-ui/icons/Close';
+import CreateIcon from '@material-ui/icons/Create';
+
+const CommentForm = () => {
+  const [formOpen, setFormOpen] = useState(false);
+  const userName = useContext(AuthContext).userName;
+  const userIconUrl = useContext(AuthContext).userIconUrl;
+  const [markdown, setMarkdown] = useState('');
+  const markdownOption = useMemo(() => {
+    return {
+      toolbar: ['preview'],
+      spellChecker: false,
+    };
+  }, []);
+
+  return (
+    <Grid container alignItems='center' justifyContent='center'>
+      {formOpen ? (
+        <Grid container>
+          <Grid item xs={12} lg={1}>
+            <Owner userName={userName} userIconUrl={userIconUrl} />
+          </Grid>
+          <Grid item xs={12} lg={11}>
+            <SimpleMDE
+              value={markdown}
+              onChange={(e) => setMarkdown(e)}
+              options={markdownOption}
+            />
+            <Grid container alignItems='center' justifyContent='center'>
+              <Button variant='contained' color='primary' style={{marginRight: 50}}>
+                <SendIcon />
+                送信
+              </Button>
+              <Button
+                variant='contained'
+                color='secondary'
+                onClick={() => setFormOpen(false)}
+              >
+                <CloseIcon />
+                キャンセル
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+      ) : (
+        <Button
+          variant='contained'
+          color='primary'
+          onClick={() => setFormOpen(true)}
+        >
+          <CreateIcon />
+          コメントする
+        </Button>
+      )}
+    </Grid>
+  );
+};
+
+export default CommentForm;

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -32,7 +32,7 @@ const CommentForm = (props) => {
       {formOpen ? (
         <Grid container>
           <Grid item xs={12} lg={1}>
-            <div style={{marginTop: 10}}>
+            <div style={{ marginTop: 10 }}>
               <Owner userName={userName} userIconUrl={userIconUrl} />
             </div>
           </Grid>
@@ -43,17 +43,27 @@ const CommentForm = (props) => {
               options={markdownOption}
             />
             <Grid container alignItems='center' justifyContent='center'>
-              {markdown.length > 0 ?
-                <Button variant='contained' color='primary' style={{marginRight: 50}} onClick={submitComment}>
+              {markdown.length > 0 ? (
+                <Button
+                  variant='contained'
+                  color='primary'
+                  style={{ marginRight: 50 }}
+                  onClick={submitComment}
+                >
                   <SendIcon />
                   送信
                 </Button>
-                :
-                <Button variant='contained' disabled style={{marginRight: 50}} onClick={submitComment}>
+              ) : (
+                <Button
+                  variant='contained'
+                  disabled
+                  style={{ marginRight: 50 }}
+                  onClick={submitComment}
+                >
                   <SendIcon />
                   送信
                 </Button>
-              }
+              )}
               <Button
                 variant='contained'
                 color='secondary'

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -26,7 +26,9 @@ const CommentForm = () => {
       {formOpen ? (
         <Grid container>
           <Grid item xs={12} lg={1}>
-            <Owner userName={userName} userIconUrl={userIconUrl} />
+            <div style={{marginTop: 10}}>
+              <Owner userName={userName} userIconUrl={userIconUrl} />
+            </div>
           </Grid>
           <Grid item xs={12} lg={11}>
             <SimpleMDE

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -27,7 +27,7 @@ const CommentList = (props) => {
 
   return (
     <div>
-      <h2>コメント一覧</h2>
+      {props.commentsAndUsers.length ? <h2>コメント一覧({props.commentsAndUsers.length}件)</h2> : <h2>コメントはまだありません</h2>}
       {props.commentsAndUsers.map((commentAndUser, i) => (
         <Grid container key={i} className={classes.comment}>
           <Grid item xs={12} lg={1}>

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -1,0 +1,59 @@
+import Owner from './Owner';
+import CreatedAt from './CreatedAt';
+import marked from 'marked';
+import DOMPurify from 'dompurify';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+
+const CommentList = (props) => {
+  const styles = makeStyles({
+    comment: {
+      marginBottom: 30,
+    },
+    commentRight: {
+      border: 'solid 1px #bbb',
+      borderRadius: '10px',
+      overflowWrap: 'break-word',
+      padding: 10,
+    },
+    commentRightFooter: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: 10,
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <div>
+      <h2>コメント一覧</h2>
+      {props.commentsAndUsers.map((commentAndUser, i) => (
+        <Grid container key={i} className={classes.comment}>
+          <Grid item xs={12} lg={1}>
+            <div style={{marginTop: 10}}>
+              <Owner
+                userName={commentAndUser.user_name}
+                userIconUrl={commentAndUser.user_icon_url}
+              />
+            </div>
+          </Grid>
+          <Grid item xs={12} lg={11} className={classes.commentRight}>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(
+                  marked(commentAndUser.comment.content)
+                ),
+              }} style={{borderBottom: 'solid 1px #bbb'}}
+            ></div>
+            <div className={classes.commentRightFooter}>
+              <CreatedAt createdAt={commentAndUser.comment.created_at} />
+            </div>
+          </Grid>
+        </Grid>
+      ))}
+    </div>
+  );
+};
+
+export default CommentList;

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -27,11 +27,15 @@ const CommentList = (props) => {
 
   return (
     <div>
-      {props.commentsAndUsers.length ? <h2>コメント一覧({props.commentsAndUsers.length}件)</h2> : <h2>コメントはまだありません</h2>}
+      {props.commentsAndUsers.length ? (
+        <h2>コメント一覧({props.commentsAndUsers.length}件)</h2>
+      ) : (
+        <h2>コメントはまだありません</h2>
+      )}
       {props.commentsAndUsers.map((commentAndUser, i) => (
         <Grid container key={i} className={classes.comment}>
           <Grid item xs={12} lg={1}>
-            <div style={{marginTop: 10}}>
+            <div style={{ marginTop: 10 }}>
               <Owner
                 userName={commentAndUser.user_name}
                 userIconUrl={commentAndUser.user_icon_url}
@@ -44,7 +48,8 @@ const CommentList = (props) => {
                 __html: DOMPurify.sanitize(
                   marked(commentAndUser.comment.content)
                 ),
-              }} style={{borderBottom: 'solid 1px #bbb'}}
+              }}
+              style={{ borderBottom: 'solid 1px #bbb' }}
             ></div>
             <div className={classes.commentRightFooter}>
               <CreatedAt createdAt={commentAndUser.comment.created_at} />

--- a/frontend/src/components/CreatedAt.js
+++ b/frontend/src/components/CreatedAt.js
@@ -1,9 +1,11 @@
 const CreatedAt = (props) => {
   return (
-    props.createdAt && <span>
-      {props.createdAt.split('T')[0].substr(0, 10)}&nbsp;
-      {props.createdAt.split('T')[1].substr(0, 5)}
-    </span>
+    props.createdAt && (
+      <span>
+        {props.createdAt.split('T')[0].substr(0, 10)}&nbsp;
+        {props.createdAt.split('T')[1].substr(0, 5)}
+      </span>
+    )
   );
 };
 

--- a/frontend/src/components/CreatedAt.js
+++ b/frontend/src/components/CreatedAt.js
@@ -1,0 +1,10 @@
+const CreatedAt = (props) => {
+  return (
+    props.createdAt && <span>
+      {props.createdAt.split('T')[0].substr(0, 10)}&nbsp;
+      {props.createdAt.split('T')[1].substr(0, 5)}
+    </span>
+  );
+};
+
+export default CreatedAt;

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -1,0 +1,37 @@
+import { makeStyles } from '@material-ui/core/styles';
+import logo from '../logo.svg';
+
+const Owner = (props) => {
+  const styles = makeStyles({
+    owner: {
+      display: 'flex',
+      flexDirection: 'column',
+      textAlign: 'center',
+    },
+    icon: {
+      border: 'solid 1px #bbb',
+      borderRadius: '50%',
+      height: 50,
+      margin: '0 auto',
+      marginTop: 20,
+      width: 50,
+    },
+    userName: {
+      overflowWrap: 'break-word',
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <div className={classes.owner}>
+      <img
+        src={props.userIconUrl ? props.userIconUrl : logo}
+        className={classes.icon}
+      />
+      <span className={classes.userName}>{props.userName}</span>
+    </div>
+  );
+};
+
+export default Owner;

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -13,7 +13,6 @@ const Owner = (props) => {
       borderRadius: '50%',
       height: 50,
       margin: '0 auto',
-      marginTop: 20,
       width: 50,
     },
     userName: {

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -7,6 +7,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Owner from './Owner';
 import CommentForm from './CommentForm';
 import CreatedAt from './CreatedAt';
+import CommentList from './CommentList';
 
 const PostDetail = (props) => {
   const { params } = props.match;
@@ -20,6 +21,7 @@ const PostDetail = (props) => {
   });
   const [ownerName, setOwnerName] = useState('');
   const [ownerIconUrl, setOwnerIconUrl] = useState(null);
+  const [commentsAndUsers, setCommentsAndUsers] = useState([]);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/posts/${id}`, {
@@ -34,6 +36,7 @@ const PostDetail = (props) => {
         setPost(res.post);
         setOwnerName(res.user.name);
         setOwnerIconUrl(res.user.icon.url);
+        setCommentsAndUsers(res.comments_and_users);
       });
   }, []);
 
@@ -124,6 +127,9 @@ const PostDetail = (props) => {
         </Grid>
         <div style={{marginTop: 50}}>
           <CommentForm />
+        </div>
+        <div style={{marginTop: 50}}>
+          <CommentList commentsAndUsers={commentsAndUsers} />
         </div>
       </Grid>
       <Grid item xs={1} sm={1} md={3} lg={3} />

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
-import logo from '../logo.svg';
+import Owner from './Owner';
 
 const PostDetail = (props) => {
   const { params } = props.match;
@@ -51,12 +51,6 @@ const PostDetail = (props) => {
     userName: {
       overflowWrap: 'break-word',
     },
-    postDetailLeft: {
-      display: 'flex',
-      flexDirection: 'column',
-      paddingRight: 5,
-      textAlign: 'center',
-    },
     postDetailRight: {
       border: 'solid 1px #bbb',
       borderRadius: '10px',
@@ -94,12 +88,8 @@ const PostDetail = (props) => {
       <Grid item xs={1} sm={1} md={3} lg={3} />
       <Grid item xs={10} sm={10} md={6} lg={6}>
         <Grid container>
-          <Grid item xs={12} lg={1} className={classes.postDetailLeft}>
-            <img
-              src={userIconUrl ? userIconUrl : logo}
-              className={classes.icon}
-            />
-            <span className={classes.userName}>{userName}</span>
+          <Grid item xs={12} lg={1}>
+            <Owner userIconUrl={userIconUrl} userName={userName} />
           </Grid>
           <Grid item xs={12} lg={11} className={classes.postDetailRight}>
             <div className={classes.postDetailRightHeader}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -16,8 +16,8 @@ const PostDetail = (props) => {
     description: '',
     created_at: '',
   });
-  const [userName, setUserName] = useState('');
-  const [userIconUrl, setUserIconUrl] = useState(null);
+  const [ownerName, setOwnerName] = useState('');
+  const [ownerIconUrl, setOwnerIconUrl] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/posts/${id}`, {
@@ -30,8 +30,8 @@ const PostDetail = (props) => {
       .then((res) => res.json())
       .then((res) => {
         setPost(res.post);
-        setUserName(res.user.name);
-        setUserIconUrl(res.user.icon.url);
+        setOwnerName(res.user.name);
+        setOwnerIconUrl(res.user.icon.url);
       });
   }, []);
 
@@ -89,7 +89,7 @@ const PostDetail = (props) => {
       <Grid item xs={10} sm={10} md={6} lg={6}>
         <Grid container>
           <Grid item xs={12} lg={1}>
-            <Owner userIconUrl={userIconUrl} userName={userName} />
+            <Owner userIconUrl={ownerIconUrl} userName={ownerName} />
           </Grid>
           <Grid item xs={12} lg={11} className={classes.postDetailRight}>
             <div className={classes.postDetailRightHeader}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -53,17 +53,20 @@ const PostDetail = (props) => {
       },
       body: JSON.stringify({
         comment: { content: markdown },
-      })
-    })
-      .then(res => {
-        if (res.status === 201) {
-          res.json().then(res => {
-            const newCommentsAndUsers = commentsAndUsers.slice();
-            newCommentsAndUsers.push({ comment: res, user_name: userName, user_icon_url: userIconUrl });
-            setCommentsAndUsers(newCommentsAndUsers);
-          })
-        }
-      })
+      }),
+    }).then((res) => {
+      if (res.status === 201) {
+        res.json().then((res) => {
+          const newCommentsAndUsers = commentsAndUsers.slice();
+          newCommentsAndUsers.push({
+            comment: res,
+            user_name: userName,
+            user_icon_url: userIconUrl,
+          });
+          setCommentsAndUsers(newCommentsAndUsers);
+        });
+      }
+    });
   };
 
   const styles = makeStyles({
@@ -151,10 +154,10 @@ const PostDetail = (props) => {
             </div>
           </Grid>
         </Grid>
-        <div style={{marginTop: 50}}>
+        <div style={{ marginTop: 50 }}>
           <CommentForm submitComment={submitComment} />
         </div>
-        <div style={{marginTop: 50}}>
+        <div style={{ marginTop: 50 }}>
           <CommentList commentsAndUsers={commentsAndUsers} />
         </div>
       </Grid>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -5,6 +5,7 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Owner from './Owner';
+import CommentForm from './CommentForm';
 
 const PostDetail = (props) => {
   const { params } = props.match;
@@ -123,6 +124,9 @@ const PostDetail = (props) => {
             </div>
           </Grid>
         </Grid>
+        <div style={{marginTop: 50}}>
+          <CommentForm />
+        </div>
       </Grid>
       <Grid item xs={1} sm={1} md={3} lg={3} />
     </Grid>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -90,7 +90,9 @@ const PostDetail = (props) => {
       <Grid item xs={10} sm={10} md={6} lg={6}>
         <Grid container>
           <Grid item xs={12} lg={1}>
-            <Owner userIconUrl={ownerIconUrl} userName={ownerName} />
+            <div style={{ marginTop: 20 }}>
+              <Owner userIconUrl={ownerIconUrl} userName={ownerName} />
+            </div>
           </Grid>
           <Grid item xs={12} lg={11} className={classes.postDetailRight}>
             <div className={classes.postDetailRightHeader}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -6,6 +6,7 @@ import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Owner from './Owner';
 import CommentForm from './CommentForm';
+import CreatedAt from './CreatedAt';
 
 const PostDetail = (props) => {
   const { params } = props.match;
@@ -117,12 +118,7 @@ const PostDetail = (props) => {
               className={classes.markdown}
             ></div>
             <div className={classes.postDetailFooter}>
-              {post.created_at && (
-                <span>
-                  {post.created_at.split('T')[0].substr(0, 10)}&nbsp;
-                  {post.created_at.split('T')[1].substr(0, 5)}に投稿
-                </span>
-              )}
+              <CreatedAt createdAt={post.created_at} />
             </div>
           </Grid>
         </Grid>

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -5,6 +5,7 @@ export const AuthContext = createContext();
 export const AuthContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(null);
   const [userName, setUserName] = useState(null);
+  const [userIconUrl, setUserIconUrl] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/sessions/logged_in`, {
@@ -18,6 +19,7 @@ export const AuthContextProvider = ({ children }) => {
         res.json().then((res) => {
           setLoggedIn(res.logged_in);
           setUserName(res.user_name);
+          setUserIconUrl(res.user_icon_url);
         });
       }
     });
@@ -25,7 +27,7 @@ export const AuthContextProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider
-      value={{ loggedIn, setLoggedIn, userName, setUserName }}
+      value={{ loggedIn, setLoggedIn, userName, setUserName, userIconUrl }}
     >
       {children}
     </AuthContext.Provider>

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    sequence(:content) { |n| "content#{n}" }
+    sequence(:user_id) { 1 }
+    sequence(:post_id) { 1 }
+  end
+end


### PR DESCRIPTION
### 関連issue
#82 

### やったこと
- seeds.rbでコメントも作成するように修正
  1件の投稿につき、2件のコメントが作成される
- GET `/posts/:id`を投稿のコメントも返すように修正
  正確には、コメントとコメントをしたユーザーの名前とユーザーのアイコン画像のURLを持ったjsonの配列を`comment_and_users`として返している
  ```ruby
  def show
    post = Post.find(params[:id])
    comments_and_users = []
    post.comments.includes(:user).each do |comment|
      comments_and_users.push({ comment: comment, user_name: comment.user.name, user_icon_url: comment.user.icon.url })
    end
    render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }
  end
  ```
- ユーザー名とアイコンの部分をOwnerコンポーネントとして作成した
- 作成日時の部分をCreatedAtコンポーネントとして作成した
- コンテキストにアイコン画像のURLも持たせるようにした
  コメント入力フォームで表示したいため。 GET `sessions/logged_in`のレスポンスも変わっている
- Material iconsのインストール
- コメントの一覧表示
- コメント入力フォームの作成

### UI
https://user-images.githubusercontent.com/61813626/140932127-b816b99c-f81b-4630-bcd2-a3d21c5e3ad2.mov

### 備考
1つのPRで作業しすぎた

### 参考
- [Material icons](https://mui.com/components/material-icons/)
- [ReactでMaterial-UI Iconを使う【入門編】](https://yoheiko.com/?p=1856)
- [RIP21/react-simplemde-editor](https://github.com/RIP21/react-simplemde-editor)
- [React hooksを基礎から理解する (useMemo編)](https://qiita.com/seira/items/42576765aecc9fa6b2f8)
- [Reactでマークダウンエディタ作成とマークダウンからHTMLに変換（ハイライト付き）](https://qiita.com/t_okkan/items/0a3318f90ee6c4468f82)
