### PR TITLE
未ログインでも投稿一覧と投稿詳細にアクセスできる

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class PostsController < ApplicationController
-      before_action :require_login, only: [:create, :update, :destroy]
+      before_action :require_login, only: %i[create update destroy]
 
       def index
         posts = Post.all.includes(:user).order(:id)

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class PostsController < ApplicationController
-      before_action :require_login
+      before_action :require_login, only: [:create, :update, :destroy]
 
       def index
         posts = Post.all.includes(:user).order(:id)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -52,10 +52,10 @@ const App = () => {
                 <PublicRoute exact path='/' component={Top} />
                 <PublicRoute path='/signup' component={Signup} />
                 <PublicRoute path='/login' component={Login} />
-                <PrivateRoute exact path='/posts' component={PostList} />
+                <Route exact path='/posts' component={PostList} />
                 <PrivateRoute path='/setting' component={Setting} />
                 <PrivateRoute path='/posts/new' component={PostForm} />
-                <PrivateRoute path='/posts/:id' component={PostDetail} />
+                <Route path='/posts/:id' component={PostDetail} />
                 <Route component={NotFound} />
               </Switch>
             </div>

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -89,12 +89,14 @@ const CommentForm = (props) => {
               コメントする
             </Button>
           ) : (
-            <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
               <Button variant='contained' disabled>
                 <CreateIcon />
                 コメントする
               </Button>
-              <Typography style={{color: 'red', marginTop: 10}}>ログインが必要です</Typography>
+              <Typography style={{ color: 'red', marginTop: 10 }}>
+                ログインが必要です
+              </Typography>
             </div>
           )}
         </>

--- a/frontend/src/components/CommentForm.js
+++ b/frontend/src/components/CommentForm.js
@@ -5,12 +5,14 @@ import SimpleMDE from 'react-simplemde-editor';
 import 'easymde/dist/easymde.min.css';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
 import SendIcon from '@material-ui/icons/Send';
 import CloseIcon from '@material-ui/icons/Close';
 import CreateIcon from '@material-ui/icons/Create';
 
 const CommentForm = (props) => {
   const [formOpen, setFormOpen] = useState(false);
+  const loggedIn = useContext(AuthContext).loggedIn;
   const userName = useContext(AuthContext).userName;
   const userIconUrl = useContext(AuthContext).userIconUrl;
   const [markdown, setMarkdown] = useState('');
@@ -76,14 +78,26 @@ const CommentForm = (props) => {
           </Grid>
         </Grid>
       ) : (
-        <Button
-          variant='contained'
-          color='primary'
-          onClick={() => setFormOpen(true)}
-        >
-          <CreateIcon />
-          コメントする
-        </Button>
+        <>
+          {loggedIn ? (
+            <Button
+              variant='contained'
+              color='primary'
+              onClick={() => setFormOpen(true)}
+            >
+              <CreateIcon />
+              コメントする
+            </Button>
+          ) : (
+            <div style={{display: 'flex', flexDirection: 'column'}}>
+              <Button variant='contained' disabled>
+                <CreateIcon />
+                コメントする
+              </Button>
+              <Typography style={{color: 'red', marginTop: 10}}>ログインが必要です</Typography>
+            </div>
+          )}
+        </>
       )}
     </Grid>
   );

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe '/api/v1/posts', type: :request do
       expect(json(response).length).to eq(10)
     end
 
-    it 'reject an unauth user' do
+    it 'accept an unauth user' do
       get '/api/v1/posts', headers: xhr_header
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(200)
     end
 
     it 'protect from CSRF' do
@@ -40,9 +40,9 @@ RSpec.describe '/api/v1/posts', type: :request do
       expect(json(response)['user']['name']).to eq(user.name)
     end
 
-    it 'reject an unauth user' do
+    it 'accept an unauth user' do
       get "/api/v1/posts/#{post.id}", headers: xhr_header
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(200)
     end
 
     it 'protect from CSRF' do


### PR DESCRIPTION
### 関連issue
#91 

### やったこと
- 未ログインユーザーも/postsと/posts/:idにアクセスできるように設定
- /posts/:idで、未ログインユーザーはコメントするボタンを押すことができない

### UI
未ログインユーザーが/posts/:idにアクセスした時
<img width="800" alt="スクリーンショット 2021-11-10 16 25 33" src="https://user-images.githubusercontent.com/61813626/141068379-1f7a83f3-7b7b-46a2-a9cf-f4935d335fa0.png">