### PR TITLE
トップページの改善

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -14,6 +14,15 @@ module Api
         render status: :ok, json: posts_and_users
       end
 
+      def recent
+        posts = Post.all.includes(:user).order(id: 'DESC').limit(4)
+        posts_and_users = []
+        posts.each do |post|
+          posts_and_users.push({ post: post, user: post.user })
+        end
+        render status: :ok, json: posts_and_users
+      end
+
       def show
         post = Post.find(params[:id])
         comments_and_users = []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
         end
       end
       resources :posts, only: %i[index show create update destroy] do
+        collection do
+          get :recent
+        end
         resources :comments, only: [:create]
       end
     end

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -4,6 +4,7 @@ import Post from './Post';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
+import CheckIcon from '@material-ui/icons/Check';
 import DoubleArrowIcon from '@material-ui/icons/DoubleArrow';
 
 const Top = () => {
@@ -32,6 +33,10 @@ const Top = () => {
       backgroundColor: 'lightgray',
       fontSize: 'calc(1px + 3vmin)',
       padding: 30,
+    },
+    appDescription: {
+      fontSize: 'calc(1px + 2.5vmin)',
+      marginLeft: 20,
     }
   });
 
@@ -45,6 +50,11 @@ const Top = () => {
           <p>ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。</p>
         </Grid>
       </Grid>
+      <h2 style={{marginLeft: 20}}>このアプリについて</h2>
+      <div className={classes.appDescription}>
+        <div><CheckIcon style={{color: 'green'}} />自分の作ったWebアプリを投稿することで、他の人からアドバイスをもらうことができます。</div>
+        <div><CheckIcon style={{color: 'green'}} />他の人のWebアプリを参考にして、自分の開発に役立てることができます。</div>
+      </div>
       <h2 style={{marginLeft: 20}}>最近の投稿</h2>
       <Grid container>
         {postsAndUsers.map((postAndUser) => (

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -1,12 +1,27 @@
+import React, { useState, useEffect } from 'react';
+import Post from './Post';
 import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 
 const Top = () => {
+  const [postsAndUsers, setPostsAndUsers] = useState([]);
+
+  useEffect(() => {
+    fetch(`${process.env.REACT_APP_API_URL}/posts/recent`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    })
+      .then(res => res.json())
+      .then(setPostsAndUsers)
+  }, []);
+
   const styles = makeStyles({
     top: {
-      alignItems: 'center',
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
@@ -28,6 +43,20 @@ const Top = () => {
           <h1>ShareFolio</h1>
           <p>ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。</p>
         </Grid>
+      </Grid>
+      <h1 style={{marginLeft: 20}}>最近の投稿</h1>
+      <Grid container>
+        {postsAndUsers.map((postAndUser) => (
+          <Grid item xs={12} sm={12} md={6} key={postAndUser.post.id}>
+            <Grid container>
+              <Grid item xs={1} />
+              <Grid item xs={10} style={{ marginBottom: 20 }}>
+                <Post postAndUser={postAndUser} />
+              </Grid>
+              <Grid item xs={1} />
+            </Grid>
+          </Grid>
+        ))}
       </Grid>
       <div style={{ display: 'flex' }}>
         <Button

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import Post from './Post';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import DoubleArrowIcon from '@material-ui/icons/DoubleArrow';
 
 const Top = () => {
   const [postsAndUsers, setPostsAndUsers] = useState([]);
@@ -56,6 +59,16 @@ const Top = () => {
           </Grid>
         ))}
       </Grid>
+      <Button
+        to='/posts'
+        component={Link}
+        variant='contained'
+        color='primary'
+        style={{margin: 'auto', marginTop: 20, marginBottom: 30}}
+      >
+        <DoubleArrowIcon />
+        全ての投稿を見る
+      </Button>
     </div>
   );
 };

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Post from './Post';
-import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
 
 const Top = () => {
   const [postsAndUsers, setPostsAndUsers] = useState([]);
@@ -58,25 +56,6 @@ const Top = () => {
           </Grid>
         ))}
       </Grid>
-      <div style={{ display: 'flex' }}>
-        <Button
-          to='/signup'
-          component={Link}
-          variant='contained'
-          color='primary'
-          style={{ marginRight: 10 }}
-        >
-          新規登録
-        </Button>
-        <Button
-          to='/login'
-          component={Link}
-          variant='contained'
-          color='primary'
-        >
-          ログイン
-        </Button>
-      </div>
     </div>
   );
 };

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -1,25 +1,34 @@
-import logo from '../logo.svg';
-import './styles/logo.css';
 import { Link } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 
 const Top = () => {
-  const style = {
-    textAlign: 'center',
-    backgroundColor: '#282c34',
-    minHeight: '100vh',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: 'calc(15px + 2vmin)',
-    color: 'white',
-  };
+  const styles = makeStyles({
+    top: {
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      paddingTop: 50,
+    },
+    jumbotron: {
+      backgroundColor: 'lightgray',
+      fontSize: 'calc(1px + 3vmin)',
+      padding: 30,
+    }
+  });
+
+  const classes = styles();
 
   return (
-    <div style={style}>
-      <img src={logo} className='App-logo' alt='logo' />
-      <p>react_rails</p>
+    <div className={classes.top}>
+      <Grid container>
+        <Grid item xs={12} className={classes.jumbotron}>
+          <h1>ShareFolio</h1>
+          <p>ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。</p>
+        </Grid>
+      </Grid>
       <div style={{ display: 'flex' }}>
         <Button
           to='/signup'

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -42,7 +42,7 @@ const Top = () => {
           <p>ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。</p>
         </Grid>
       </Grid>
-      <h1 style={{marginLeft: 20}}>最近の投稿</h1>
+      <h2 style={{marginLeft: 20}}>最近の投稿</h2>
       <Grid container>
         {postsAndUsers.map((postAndUser) => (
           <Grid item xs={12} sm={12} md={6} key={postAndUser.post.id}>

--- a/frontend/src/components/Top.js
+++ b/frontend/src/components/Top.js
@@ -18,8 +18,8 @@ const Top = () => {
         'X-Requested-With': 'XMLHttpRequest',
       },
     })
-      .then(res => res.json())
-      .then(setPostsAndUsers)
+      .then((res) => res.json())
+      .then(setPostsAndUsers);
   }, []);
 
   const styles = makeStyles({
@@ -37,7 +37,7 @@ const Top = () => {
     appDescription: {
       fontSize: 'calc(1px + 2.5vmin)',
       marginLeft: 20,
-    }
+    },
   });
 
   const classes = styles();
@@ -47,15 +47,23 @@ const Top = () => {
       <Grid container>
         <Grid item xs={12} className={classes.jumbotron}>
           <h1>ShareFolio</h1>
-          <p>ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。</p>
+          <p>
+            ShareFolioはWebエンジニアを目指す人のためのポートフォリオプラットフォームです。
+          </p>
         </Grid>
       </Grid>
-      <h2 style={{marginLeft: 20}}>このアプリについて</h2>
+      <h2 style={{ marginLeft: 20 }}>このアプリについて</h2>
       <div className={classes.appDescription}>
-        <div><CheckIcon style={{color: 'green'}} />自分の作ったWebアプリを投稿することで、他の人からアドバイスをもらうことができます。</div>
-        <div><CheckIcon style={{color: 'green'}} />他の人のWebアプリを参考にして、自分の開発に役立てることができます。</div>
+        <div>
+          <CheckIcon style={{ color: 'green' }} />
+          自分の作ったWebアプリを投稿することで、他の人からアドバイスをもらうことができます。
+        </div>
+        <div>
+          <CheckIcon style={{ color: 'green' }} />
+          他の人のWebアプリを参考にして、自分の開発に役立てることができます。
+        </div>
       </div>
-      <h2 style={{marginLeft: 20}}>最近の投稿</h2>
+      <h2 style={{ marginLeft: 20 }}>最近の投稿</h2>
       <Grid container>
         {postsAndUsers.map((postAndUser) => (
           <Grid item xs={12} sm={12} md={6} key={postAndUser.post.id}>
@@ -74,7 +82,7 @@ const Top = () => {
         component={Link}
         variant='contained'
         color='primary'
-        style={{margin: 'auto', marginTop: 20, marginBottom: 30}}
+        style={{ margin: 'auto', marginTop: 20, marginBottom: 30 }}
       >
         <DoubleArrowIcon />
         全ての投稿を見る


### PR DESCRIPTION
### 関連issue
#93 

### やったこと
- ジャンボトロンの設置
  背景を画像にしようかと思ったが、レスポンシブ対応が難しいので、一旦灰色
- 新規登録ボタン、ログインボタンを削除
  ヘッダーにリンクがあるので大丈夫
- アプリの説明文を記載
- GET `/posts/recent`を作成
- 直近4件の投稿を表示
- 投稿一覧へのリンクを設置

### UI
<img width="800" alt="スクリーンショット 2021-11-10 19 10 00" src="https://user-images.githubusercontent.com/61813626/141093925-e5f5d6de-a0fc-4e2d-9d8c-3d9776d62f02.png">

### 参考
- [create-react-appでlocalのbackgroundImageが表示されない時の対処法](https://qiita.com/kikkakesan/items/c1a40bb5aecd97aaab63)
- [background-repeat](https://developer.mozilla.org/ja/docs/Web/CSS/background-repeat)
- [font-sizeの単位をvwにしてデバイスサイズに合わせて拡縮する](https://qiita.com/katsunory/items/3bede89cee8e2ded8426)
- [WEB色見本 原色大辞典 - HTMLカラーコード](https://www.colordic.org/)
- [Railsドキュメント](https://railsdoc.com/page/limit)
- [rails 昇順、降順の並び替え](https://qiita.com/tsuchinoko_run/items/c31ed7e0b0672e6d898a)
- [意外と知られていないCSSのmargin:0 autoなどの無駄な指定](https://iwb.jp/css-wasted-properties/)
- [htmlではタグで囲まないでそのまま文字を打ってもブラウザに反映されるのですがこれはどういう扱いなのでしょうか](https://detail.chiebukuro.yahoo.co.jp/qa/question_detail/q14118978394)