### PR TITLE
login, logoutの不要な処理を削除

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { useHistory } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 import Link from '@material-ui/core/Link';
 import CreateIcon from '@mui/icons-material/Create';
@@ -12,8 +11,6 @@ const Header = () => {
   const loggedIn = useContext(AuthContext).loggedIn;
   const setLoggedIn = useContext(AuthContext).setLoggedIn;
   const userName = useContext(AuthContext).userName;
-  const setUserName = useContext(AuthContext).setUserName;
-  const history = useHistory();
 
   const logout = () => {
     fetch(`${process.env.REACT_APP_API_URL}/sessions/logout`, {
@@ -25,8 +22,6 @@ const Header = () => {
     }).then((res) => {
       if (res.status == 204) {
         setLoggedIn(false);
-        setUserName(null);
-        history.push('/login');
       }
     });
   };

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -1,5 +1,4 @@
 import React, { useState, useContext } from 'react';
-import { useHistory } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
@@ -13,7 +12,6 @@ const Login = () => {
     password: '',
   });
   const [errorMessage, setErrorMessage] = useState('');
-  const history = useHistory();
   const setLoggedIn = useContext(AuthContext).setLoggedIn;
   const setUserName = useContext(AuthContext).setUserName;
 
@@ -37,7 +35,6 @@ const Login = () => {
         res.json().then((res) => {
           setLoggedIn(true);
           setUserName(res.user_name);
-          history.push('/posts');
         });
       } else if (res.status === 401) {
         setErrorMessage('Invalid email/password combination');


### PR DESCRIPTION
### やったこと
コンテキストの`loggedIn`が変更されれば、App.jsで自動的にレンダリングされるコンポーネントが切り替わるので、`history.push`はいらない あと`logout`関数の`setUserName(null)`もいらないので削除

### 参考
- [yuta-ike/private-router-sample](https://github.com/yuta-ike/private-router-sample/tree/master/src)