### PR TITLE
コメントがついたことをメールで通知する

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -8,9 +8,7 @@ module Api
       def create
         comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))
         if comment.save
-          if current_user.id != comment.post.user.id
-            CommentMailer.comment_notification(comment).deliver_now
-          end
+          CommentMailer.comment_notification(comment).deliver_now if current_user.id != comment.post.user.id
           render status: :created, json: comment
         else
           render status: :bad_request, json: comment.errors

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -8,6 +8,9 @@ module Api
       def create
         comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))
         if comment.save
+          if current_user.id != comment.post.user.id
+            CommentMailer.comment_notification(comment).deliver_now
+          end
           render status: :created, json: comment
         else
           render status: :bad_request, json: comment.errors

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "noreply@#{ENV['MAILGUN_DOMAIN']}"
   layout 'mailer'
 end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -1,0 +1,13 @@
+class CommentMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.comment_mailer.comment_notification.subject
+  #
+  def comment_notification(comment)
+    @post = comment.post
+    @user = @post.user
+    mail to: @user.email, subject: "[ShareFolioからのお知らせ] コメントがつきました！"
+  end
+end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -1,5 +1,6 @@
-class CommentMailer < ApplicationMailer
+# frozen_string_literal: true
 
+class CommentMailer < ApplicationMailer
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
@@ -8,6 +9,6 @@ class CommentMailer < ApplicationMailer
   def comment_notification(comment)
     @post = comment.post
     @user = @post.user
-    mail to: @user.email, subject: "[ShareFolioからのお知らせ] コメントがつきました！"
+    mail to: @user.email, subject: '[ShareFolioからのお知らせ] コメントがつきました！'
   end
 end

--- a/app/views/comment_mailer/comment_notification.html.erb
+++ b/app/views/comment_mailer/comment_notification.html.erb
@@ -1,0 +1,2 @@
+<%= @user.name %>さんの<%= @post.app_name %>にコメントがつきました！<br>
+<%= link_to 'このリンク', "#{ENV['FRONTEND_ORIGIN']}/posts/#{@post.id}" %>からご確認ください。

--- a/app/views/comment_mailer/comment_notification.text.erb
+++ b/app/views/comment_mailer/comment_notification.text.erb
@@ -1,0 +1,2 @@
+<%= @user.name %>さんの<%= @post.app_name %>にコメントがつきました！
+<%= "#{ENV['FRONTEND_ORIGIN']}/posts/#{@post.id}" %>からご確認ください。

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = ENV['BACKEND_ORIGIN']
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,18 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = ENV['FRONTEND_ORIGIN']
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :port           => ENV['MAILGUN_SMTP_PORT'],
+    :address        => ENV['MAILGUN_SMTP_SERVER'],
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => host,
+    :authentication => :plain,
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,12 +66,12 @@ Rails.application.configure do
   host = ENV['FRONTEND_ORIGIN']
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => ENV['MAILGUN_SMTP_PORT'],
-    :address        => ENV['MAILGUN_SMTP_SERVER'],
-    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
-    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => host,
-    :authentication => :plain,
+    port: ENV['MAILGUN_SMTP_PORT'],
+    address: ENV['MAILGUN_SMTP_SERVER'],
+    user_name: ENV['MAILGUN_SMTP_LOGIN'],
+    password: ENV['MAILGUN_SMTP_PASSWORD'],
+    domain: host,
+    authentication: :plain,
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe CommentMailer, type: :mailer do
+  describe 'comment_notification' do
+    let!(:user) { create(:user) }
+    let!(:post) { create(:post) }
+    let(:comment) { create(:comment) }
+    let(:mail) { CommentMailer.comment_notification(comment) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('[ShareFolioからのお知らせ] コメントがつきました！')
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["noreply@#{ENV['MAILGUN_DOMAIN']}"])
+    end
+  end
+end

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CommentMailer, type: :mailer do
   describe 'comment_notification' do
     let!(:user) { create(:user) }
-    let!(:post) { create(:post) }
-    let(:comment) { create(:comment) }
-    let(:mail) { CommentMailer.comment_notification(comment) }
+    let(:post) { create(:post) }
+    let(:comment) { create(:comment, post_id: post.id) }
+    let(:mail) { described_class.comment_notification(comment) }
 
     it 'renders the headers' do
       expect(mail.subject).to eq('[ShareFolioからのお知らせ] コメントがつきました！')
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["noreply@#{ENV['MAILGUN_DOMAIN']}"])
     end
   end
 end

--- a/spec/mailers/previews/comment_mailer_preview.rb
+++ b/spec/mailers/previews/comment_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/comment_mailer
+class CommentMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/comment_mailer/comment_notification
+  def comment_notification
+    CommentMailer.comment_notification(Comment.first)
+  end
+
+end

--- a/spec/mailers/previews/comment_mailer_preview.rb
+++ b/spec/mailers/previews/comment_mailer_preview.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 # Preview all emails at http://localhost:3000/rails/mailers/comment_mailer
 class CommentMailerPreview < ActionMailer::Preview
-
   # Preview this email at http://localhost:3000/rails/mailers/comment_mailer/comment_notification
   def comment_notification
     CommentMailer.comment_notification(Comment.first)
   end
-
 end


### PR DESCRIPTION
### 関連issue
#105 

### やったこと
- お名前.comでドメインの取得
- DNSにSPFとDKIMを設定
- メーラーの作成 & メールビューの作成
- ローカルでのメールプレビューの設定
- メールの送信テストを記述
- メールの送信処理を記述
  コメントがついたとき、コメントしたユーザーと投稿のユーザーが異なるときに、メールを送信する
- 本番環境でのメール送信の設定
  Herokuの環境変数の書き換え等

### UI
メール
<img width="600" alt="スクリーンショット 2021-11-14 15 21 02" src="https://user-images.githubusercontent.com/61813626/141670096-1971c762-d46c-44fd-ba35-595920733bfd.png">

### 備考
icloudだと`Sender address rejected: Domain not found`と出て、メールが受信されない
gmailだと送れるには送れるが、迷惑メールに振り分けられてしまう

### 参考
- [アカウント有効化のメール送信](https://railstutorial.jp/chapters/account_activation?version=5.1#sec-account_activation_emails)
- [Mailgunで特定のアドレス以外にメールが送れない（Heroku）](https://teratail.com/questions/352729)
- [メール配信サービスMailgunでメール送信するための手順をまとめてみた](https://tech.arms-soft.co.jp/entry/2019/12/11/090000)
- [Laravelのメール送信機能でHerokuのMailgun使った時ハマりまくったのでうまくいった設定とか書く](https://qiita.com/Yorinton/items/9ec1c92a72696fac88f6)
- [Net::SMTPSyntaxError · 501 Invalid command or cannot parse from address](https://stackoverflow.com/questions/56122806/netsmtpsyntaxerror-501-invalid-command-or-cannot-parse-from-address)
- [whatsmydns.net - DNS Propagation Checker](https://www.whatsmydns.net/#TXT/sharefolio.site)
- [メールが迷惑メールフォルダに振り分けられる時のチェックリスト](https://support.karte.io/post/5cNIgC9X2fyvgNLHpIzGMq)