### PR TITLE
ロード中にスピナーを表示

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13198,6 +13198,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-md-spinner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-md-spinner/-/react-md-spinner-1.0.0.tgz",
+      "integrity": "sha512-W3akCl5v/qBKhsrRsIxMl+hNQojj+SiN0+wdMAsXDfoYhQhtyg9LAdsC7P/1r3bYAJsjDmi4f5qz0N5lh26FiQ==",
+      "requires": {
+        "stylis": "^3.5.4"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+          "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "marked": "^3.0.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-md-spinner": "^1.0.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
     "react-simplemde-editor": "^5.0.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,11 +11,16 @@ import Setting from './pages/Setting';
 import PostForm from './pages/PostForm';
 import NotFound from './pages/NotFound';
 import Footer from './components/Footer';
+import MDSpinner from 'react-md-spinner';
 
 const WaitInitialize = ({ children }) => {
   const initialized = useContext(AuthContext);
   if (initialized.loggedIn === null) {
-    return <div>初期化中</div>;
+    return (
+      <div style={{ marginTop: 100, textAlign: 'center' }}>
+        <MDSpinner size={70} />
+      </div>
+    );
   }
   return <>{children}</>;
 };

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -9,20 +9,15 @@ import Owner from '../components/Owner';
 import CommentForm from '../components/CommentForm';
 import CreatedAt from '../components/CreatedAt';
 import CommentList from '../components/CommentList';
+import MDSpinner from 'react-md-spinner';
 
 const PostDetail = (props) => {
   const { params } = props.match;
   const id = parseInt(params.id, 10);
-  const [post, setPost] = useState({
-    app_name: '',
-    app_url: '',
-    repo_url: '',
-    description: '',
-    created_at: '',
-  });
+  const [post, setPost] = useState(null);
   const [ownerName, setOwnerName] = useState('');
   const [ownerIconUrl, setOwnerIconUrl] = useState(null);
-  const [commentsAndUsers, setCommentsAndUsers] = useState([]);
+  const [commentsAndUsers, setCommentsAndUsers] = useState(null);
   const userName = useContext(AuthContext).userName;
   const userIconUrl = useContext(AuthContext).userIconUrl;
 
@@ -116,8 +111,17 @@ const PostDetail = (props) => {
   });
 
   const classes = styles();
+  const isLoading =
+    post === null ||
+    ownerName === null ||
+    ownerIconUrl === null ||
+    commentsAndUsers === null;
 
-  return (
+  return isLoading ? (
+    <div style={{ marginTop: 100, textAlign: 'center' }}>
+      <MDSpinner size={70} />
+    </div>
+  ) : (
     <Grid container className={classes.postDetail}>
       <Grid item xs={1} sm={1} md={3} lg={3} />
       <Grid item xs={10} sm={10} md={6} lg={6}>

--- a/frontend/src/pages/PostList.js
+++ b/frontend/src/pages/PostList.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Post from '../components/Post';
+import MDSpinner from 'react-md-spinner';
 
 const App = () => {
-  const [postAndUsers, setPostAndUsers] = useState([]);
+  const [postAndUsers, setPostAndUsers] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/posts`, {
@@ -17,7 +18,13 @@ const App = () => {
       .then(setPostAndUsers);
   }, []);
 
-  return (
+  const isLoading = postAndUsers === null;
+
+  return isLoading ? (
+    <div style={{ paddingTop: 100, textAlign: 'center' }}>
+      <MDSpinner size={70} />
+    </div>
+  ) : (
     <div style={{ paddingTop: 50 }}>
       <div
         style={{

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -3,14 +3,10 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import defaultIcon from '../logo.svg';
+import MDSpinner from 'react-md-spinner';
 
 const Setting = () => {
-  const [inputValue, setInputValue] = useState({
-    name: '',
-    email: '',
-    password: '',
-    password_confirmation: '',
-  });
+  const [inputValue, setInputValue] = useState(null);
   const [validationMessage, setValidationMessage] = useState({
     name: '',
     email: '',
@@ -18,7 +14,7 @@ const Setting = () => {
     password_confirmation: '',
   });
   const [icon, setIcon] = useState(null);
-  const [preview, setPreview] = useState(null);
+  const [preview, setPreview] = useState('');
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
@@ -107,7 +103,13 @@ const Setting = () => {
     reader.readAsDataURL(file);
   };
 
-  return (
+  const isLoading = inputValue === null || preview === '';
+
+  return isLoading ? (
+    <div style={{ marginTop: 100, textAlign: 'center' }}>
+      <MDSpinner size={70} />
+    </div>
+  ) : (
     <Grid
       container
       direction='column'

--- a/frontend/src/pages/Top.js
+++ b/frontend/src/pages/Top.js
@@ -6,9 +6,10 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import CheckIcon from '@mui/icons-material/Check';
 import DoubleArrowIcon from '@mui/icons-material/DoubleArrow';
+import MDSpinner from 'react-md-spinner';
 
 const Top = () => {
-  const [postsAndUsers, setPostsAndUsers] = useState([]);
+  const [postsAndUsers, setPostsAndUsers] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/posts/recent`, {
@@ -68,29 +69,37 @@ const Top = () => {
         </div>
       </div>
       <h2 style={{ marginLeft: 20 }}>最近の投稿</h2>
-      <Grid container>
-        {postsAndUsers.map((postAndUser) => (
-          <Grid item xs={12} sm={12} md={6} key={postAndUser.post.id}>
-            <Grid container>
-              <Grid item xs={1} />
-              <Grid item xs={10} style={{ marginBottom: 20 }}>
-                <Post postAndUser={postAndUser} />
+      {postsAndUsers === null ? (
+        <div style={{ marginTop: 20, textAlign: 'center' }}>
+          <MDSpinner size={70} />
+        </div>
+      ) : (
+        <>
+          <Grid container>
+            {postsAndUsers.map((postAndUser) => (
+              <Grid item xs={12} sm={12} md={6} key={postAndUser.post.id}>
+                <Grid container>
+                  <Grid item xs={1} />
+                  <Grid item xs={10} style={{ marginBottom: 20 }}>
+                    <Post postAndUser={postAndUser} />
+                  </Grid>
+                  <Grid item xs={1} />
+                </Grid>
               </Grid>
-              <Grid item xs={1} />
-            </Grid>
+            ))}
           </Grid>
-        ))}
-      </Grid>
-      <Button
-        to='/posts'
-        component={Link}
-        variant='contained'
-        color='primary'
-        style={{ margin: 'auto', marginTop: 20, marginBottom: 30 }}
-      >
-        <DoubleArrowIcon />
-        全ての投稿を見る
-      </Button>
+          <Button
+            to='/posts'
+            component={Link}
+            variant='contained'
+            color='primary'
+            style={{ margin: 'auto', marginTop: 20, marginBottom: 30 }}
+          >
+            <DoubleArrowIcon />
+            全ての投稿を見る
+          </Button>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### 関連issue
#116 

### やったこと
- MD Spinnerをインストール
- トップ画面、投稿一覧画面、投稿詳細画面、ユーザー情報設定画面で、fetchが終わるまで、スピナーを表示するようにした

### UI
(わざと3秒間スリープしている)

https://user-images.githubusercontent.com/61813626/141801647-4f9182d5-c880-4d25-a31b-0a74f7f497e9.mov

### 備考
sleepさせる関数ぐらいパッと書けるようになろう
```javascript
const sleep = (sec) => {
  return new Promise(resolve => setTimeout(resolve, 1000 * sec));
};
```

### 参考
- [Reactで使えるMaterial DesignのSpinnerコンポーネントを作った](https://blog.wadackel.me/2016/react-md-spinner/)
- [reactでpropsを受け取るときにの({})と()の違いについて](https://teratail.com/questions/139499)
- [props.childrenを渡す方法](https://qiita.com/makkkiy/items/30dd32b815c63efdb64d)