### PR TITLE
フラッシュメッセージの表示

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import AuthContextProvider, { AuthContext } from './contexts/AuthContext';
+import FlashMessageContextProvider from './contexts/FlashMessageContext';
+import FlashMessage from './components/FlashMessage';
 import Header from './components/Header';
 import Top from './pages/Top';
 import Signup from './pages/Signup';
@@ -46,28 +48,35 @@ const PrivateRoute = ({ ...props }) => {
 const App = () => {
   return (
     <AuthContextProvider>
-      <WaitInitialize>
-        <BrowserRouter>
-          <div
-            style={{ display: 'flex', flexFlow: 'column', minHeight: '100vh' }}
-          >
-            <Header />
-            <div style={{ flex: 1 }}>
-              <Switch>
-                <PublicRoute exact path='/' component={Top} />
-                <PublicRoute path='/signup' component={Signup} />
-                <PublicRoute path='/login' component={Login} />
-                <Route exact path='/posts' component={PostList} />
-                <PrivateRoute path='/setting' component={Setting} />
-                <PrivateRoute path='/posts/new' component={PostForm} />
-                <Route path='/posts/:id' component={PostDetail} />
-                <Route component={NotFound} />
-              </Switch>
+      <FlashMessageContextProvider>
+        <WaitInitialize>
+          <BrowserRouter>
+            <div
+              style={{
+                display: 'flex',
+                flexFlow: 'column',
+                minHeight: '100vh',
+              }}
+            >
+              <Header />
+              <FlashMessage />
+              <div style={{ flex: 1 }}>
+                <Switch>
+                  <PublicRoute exact path='/' component={Top} />
+                  <PublicRoute path='/signup' component={Signup} />
+                  <PublicRoute path='/login' component={Login} />
+                  <Route exact path='/posts' component={PostList} />
+                  <PrivateRoute path='/setting' component={Setting} />
+                  <PrivateRoute path='/posts/new' component={PostForm} />
+                  <Route path='/posts/:id' component={PostDetail} />
+                  <Route component={NotFound} />
+                </Switch>
+              </div>
+              <Footer />
             </div>
-            <Footer />
-          </div>
-        </BrowserRouter>
-      </WaitInitialize>
+          </BrowserRouter>
+        </WaitInitialize>
+      </FlashMessageContextProvider>
     </AuthContextProvider>
   );
 };

--- a/frontend/src/components/FlashMessage.js
+++ b/frontend/src/components/FlashMessage.js
@@ -1,0 +1,46 @@
+import { useContext } from 'react';
+import { FlashMessageContext } from '../contexts/FlashMessageContext';
+import { makeStyles } from '@material-ui/core/styles';
+
+const FlashMessage = () => {
+  const flashMessage = useContext(FlashMessageContext).flashMessage;
+  const isOpen = useContext(FlashMessageContext).isOpen;
+
+  const styles = makeStyles({
+    outer: {
+      marginTop: 50,
+      position: 'fixed',
+      width: '100%',
+      zIndex: 2,
+    },
+    flashMessage: {
+      backgroundColor: flashMessage.success ? '#DFF0D8' : '#F2DEDE',
+      borderRadius: 20,
+      margin: 'auto',
+      opacity: isOpen ? 1 : 0,
+      padding: '10px 0px',
+      transition: 'all 1s',
+      textAlign: 'center',
+      width: 400,
+    },
+    successMessage: {
+      color: '#3C763D',
+    },
+    errorMessage: {
+      color: '#A94442',
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <div className={classes.outer}>
+      <div className={classes.flashMessage}>
+        {flashMessage.success && <span className={classes.successMessage}>{flashMessage.success}</span>}
+        {flashMessage.error && <span className={classes.errorMessage}>{flashMessage.error}</span>}
+      </div>
+    </div>
+  );
+};
+
+export default FlashMessage;

--- a/frontend/src/components/FlashMessage.js
+++ b/frontend/src/components/FlashMessage.js
@@ -36,8 +36,12 @@ const FlashMessage = () => {
   return (
     <div className={classes.outer}>
       <div className={classes.flashMessage}>
-        {flashMessage.success && <span className={classes.successMessage}>{flashMessage.success}</span>}
-        {flashMessage.error && <span className={classes.errorMessage}>{flashMessage.error}</span>}
+        {flashMessage.success && (
+          <span className={classes.successMessage}>{flashMessage.success}</span>
+        )}
+        {flashMessage.error && (
+          <span className={classes.errorMessage}>{flashMessage.error}</span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
+import { FlashMessageContext } from '../contexts/FlashMessageContext';
 import Link from '@material-ui/core/Link';
 import CreateIcon from '@mui/icons-material/Create';
 import PersonIcon from '@mui/icons-material/Person';
@@ -12,6 +13,7 @@ const Header = () => {
   const loggedIn = useContext(AuthContext).loggedIn;
   const setLoggedIn = useContext(AuthContext).setLoggedIn;
   const userName = useContext(AuthContext).userName;
+  const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const history = useHistory();
 
   const logout = () => {
@@ -24,6 +26,7 @@ const Header = () => {
     }).then((res) => {
       if (res.status == 204) {
         setLoggedIn(false);
+        updateFlashMessage({ successMessage: 'ログアウトしました' });
         history.push('/');
       }
     });

--- a/frontend/src/contexts/FlashMessageContext.js
+++ b/frontend/src/contexts/FlashMessageContext.js
@@ -1,0 +1,27 @@
+import React, { createContext, useState } from 'react';
+
+export const FlashMessageContext = createContext();
+
+export const FlashMessageContextProvider = ({ children }) => {
+  const [flashMessage, setFlashMessage] = useState({ success: '', error: '' });
+  const [isOpen, setOpen] = useState(false);
+
+  const updateFlashMessage = ({ successMessage, errorMessage }) => {
+    setFlashMessage({
+      success: successMessage ? successMessage : '',
+      error: errorMessage ? errorMessage : '',
+    });
+    setOpen(true);
+    setTimeout(() => setOpen(false), 1500);
+  };
+
+  return (
+    <FlashMessageContext.Provider
+      value={{ flashMessage, updateFlashMessage, isOpen }}
+    >
+      {children}
+    </FlashMessageContext.Provider>
+  );
+};
+
+export default FlashMessageContextProvider;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
+import { FlashMessageContext } from '../contexts/FlashMessageContext';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
@@ -14,6 +15,7 @@ const Login = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const setLoggedIn = useContext(AuthContext).setLoggedIn;
   const setUserName = useContext(AuthContext).setUserName;
+  const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
 
   const changeInputValue = (itemName, e) => {
     const newInputValue = Object.assign({}, inputValue);
@@ -35,6 +37,7 @@ const Login = () => {
         res.json().then((res) => {
           setLoggedIn(true);
           setUserName(res.user_name);
+          updateFlashMessage({ successMessage: 'ログインしました' });
         });
       } else if (res.status === 401) {
         setErrorMessage('Invalid email/password combination');

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
+import { FlashMessageContext } from '../contexts/FlashMessageContext';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
@@ -15,6 +16,7 @@ const Setting = () => {
   });
   const [icon, setIcon] = useState(null);
   const [preview, setPreview] = useState('');
+  const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
@@ -70,6 +72,7 @@ const Setting = () => {
           password_confirmation: '',
         };
         setValidationMessage(newValidationMessage);
+        updateFlashMessage({ successMessage: 'プロフィールを更新しました' });
       } else if (res.status === 400) {
         res.json().then((err) => {
           const newValidationMessage = {


### PR DESCRIPTION
### 関連issue
#59 

### やったこと
- フラッシュメッセージを管理するコンテキストを作成
- ログイン時、ログアウト時、プロフィール更新時に、成功したことを伝えるフラッシュメッセージを表示する

### UI

https://user-images.githubusercontent.com/61813626/142161907-b808f023-7bab-433c-b251-3cea629c647b.mov

### 備考
ログインしていない状態で、/posts/newにアクセスした時、ログイン画面にリダイレクトするようになっているが、その時にエラーメッセージを出す実装ができなかった。`PrivateRoute`の中で`updateFlashMessage`を実行すると、`Warning: Cannot update a component while rendering a different component`というエラーが発生し、Loginコンポーネントの中で`useEffect`を使って、実行すると、フェードインが動作しない。数秒スリープさせた後で、実行すると上手くいったが、良くない実装だと思うので、含めなかった。レンダリングされる前に実行されているためだと考えられる。

### 参考
- [React.js　でflashメッセージを実装したい](https://teratail.com/questions/365887)
- [position:fixedを使用した際に子要素のmargin:0 autoが効かなくなる？](https://teratail.com/questions/206108?link=qa_related_pc)
- [CSSで文字を上下左右中央に配置する方法いろいろ](https://www.esz.co.jp/blog/2847.html)
- [手軽なCSSアニメーション！transitionプロパティの使い方（基礎編）](https://www.asobou.co.jp/blog/web/css-animation3)
- [React Hooks: 子コンポーネントから親の状態をレンダー時に変えたら叱られた ー Warning: Cannot update a component while rendering a different component](https://qiita.com/FumioNonaka/items/3fe39911e3f2479128e8#%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%81%8C%E6%B8%88%E3%82%93%E3%81%A7%E3%81%8B%E3%82%89%E8%A6%AA%E3%81%AE%E7%8A%B6%E6%85%8B%E3%82%92%E5%A4%89%E3%81%88%E3%82%8B)
- [CSSのクラス名を決めるときに使うリストをつくりました](https://qiita.com/manabuyasuda/items/dbb76ed36970bec95470)