### PR TITLE
プロバイダーから受け取ったアイコンをデータベースに保存する

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -28,7 +28,7 @@ module Api
         comments_and_users = []
         post.comments.includes(:user).each do |comment|
           user = comment.user
-          user_icon_url = user.upload_icon.url ? user.upload_icon.url : user.default_icon_url
+          user_icon_url = user.upload_icon.url || user.default_icon_url
           comments_and_users.push({ comment: comment, user_name: user.name, user_icon_url: user_icon_url })
         end
         render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -27,7 +27,9 @@ module Api
         post = Post.find(params[:id])
         comments_and_users = []
         post.comments.includes(:user).each do |comment|
-          comments_and_users.push({ comment: comment, user_name: comment.user.name, user_icon_url: comment.user.icon.url })
+          user = comment.user
+          user_icon_url = user.upload_icon.url ? user.upload_icon.url : user.default_icon_url
+          comments_and_users.push({ comment: comment, user_name: user.name, user_icon_url: user_icon_url })
         end
         render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -50,7 +50,8 @@ module Api
         params.require(:user).permit(
           :name,
           :email,
-          :icon,
+          :upload_icon,
+          :default_icon_url,
         )
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
     length: { maximum: 255 },
     format: { with: VALID_EMAIL_REGEX },
   }
-  mount_uploader :icon, IconUploader
+  mount_uploader :upload_icon, IconUploader
+  validates :default_icon_url, presence: true
   validates :uid, presence: true
 end

--- a/db/migrate/20211127175204_change_icon_column_of_users.rb
+++ b/db/migrate/20211127175204_change_icon_column_of_users.rb
@@ -1,0 +1,6 @@
+class ChangeIconColumnOfUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :icon, :upload_icon
+    add_column :users, :default_icon_url, :string, null: false
+  end
+end

--- a/db/migrate/20211127175204_change_icon_column_of_users.rb
+++ b/db/migrate/20211127175204_change_icon_column_of_users.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 class ChangeIconColumnOfUsers < ActiveRecord::Migration[6.1]
   def change
-    rename_column :users, :icon, :upload_icon
-    add_column :users, :default_icon_url, :string, null: false
+    change_table :users do |t|
+      t.rename :icon, :upload_icon
+      t.string :default_icon_url, null: false
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_25_075739) do
+ActiveRecord::Schema.define(version: 2021_11_27_175204) do
 
   create_table "comments", force: :cascade do |t|
     t.string "content", null: false
@@ -38,8 +38,9 @@ ActiveRecord::Schema.define(version: 2021_11_25_075739) do
     t.string "email", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "icon"
+    t.string "upload_icon"
     t.string "uid", null: false
+    t.string "default_icon_url", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -23,10 +23,7 @@ const Owner = (props) => {
 
   return (
     <div className={classes.owner}>
-      <img
-        src={props.userIconUrl}
-        className={classes.icon}
-      />
+      <img src={props.userIconUrl} className={classes.icon} />
       <span className={classes.userName}>{props.userName}</span>
     </div>
   );

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -1,5 +1,4 @@
 import { makeStyles } from '@material-ui/core/styles';
-import logo from '../logo.svg';
 
 const Owner = (props) => {
   const styles = makeStyles({
@@ -25,7 +24,7 @@ const Owner = (props) => {
   return (
     <div className={classes.owner}>
       <img
-        src={props.userIconUrl ? props.userIconUrl : logo}
+        src={props.userIconUrl}
         className={classes.icon}
       />
       <span className={classes.userName}>{props.userName}</span>

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -12,7 +12,9 @@ const Post = (props) => {
 
   const user = props.postAndUser.user;
   const userName = user.name;
-  const userIconUrl = user.upload_icon.url ? user.upload_icon.url : user.default_icon_url;
+  const userIconUrl = user.upload_icon.url
+    ? user.upload_icon.url
+    : user.default_icon_url;
 
   const previewDescription = (description) => {
     let result = '';

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -12,7 +12,7 @@ const Post = (props) => {
 
   const user = props.postAndUser.user;
   const userName = user.name;
-  const userIconUrl = user.icon.url;
+  const userIconUrl = user.upload_icon.url ? user.upload_icon.url : user.default_icon_url;
 
   const previewDescription = (description) => {
     let result = '';

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -17,7 +17,7 @@ export const AuthContextProvider = ({ children }) => {
       setLoggedIn(true);
       axiosAuthClient.get(`/users/search?uid=${uid}`).then((res) => {
         setUserName(res.data.name);
-        setUserIconUrl(res.data.icon.url);
+        setUserIconUrl(res.data.upload_icon.url ? res.data.upload_icon.url : res.data.default_icon_url);
       });
     } else {
       setLoggedIn(false);

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -17,7 +17,11 @@ export const AuthContextProvider = ({ children }) => {
       setLoggedIn(true);
       axiosAuthClient.get(`/users/search?uid=${uid}`).then((res) => {
         setUserName(res.data.name);
-        setUserIconUrl(res.data.upload_icon.url ? res.data.upload_icon.url : res.data.default_icon_url);
+        setUserIconUrl(
+          res.data.upload_icon.url
+            ? res.data.upload_icon.url
+            : res.data.default_icon_url
+        );
       });
     } else {
       setLoggedIn(false);

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -21,10 +21,10 @@ const Login = () => {
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const [errorMessage, setErrorMessage] = useState('');
 
-  const createUser = (name, email, icon, token) => {
+  const createUser = (name, email, default_icon_url, token) => {
     axiosAuthClient
       .post('/users', {
-        user: { name: name, email: email, icon: icon },
+        user: { name: name, email: email, default_icon_url: default_icon_url },
         token: token,
       })
       .then((res) => {
@@ -40,9 +40,9 @@ const Login = () => {
       .then((res) => {
         const name = res.additionalUserInfo.username;
         const email = res.user.email;
-        const icon = res.user.photoURL;
+        const default_icon_url = res.user.photoURL;
         const token = res.user.Aa;
-        createUser(name, email, icon, token);
+        createUser(name, email, default_icon_url, token);
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {
@@ -59,9 +59,9 @@ const Login = () => {
       .then((res) => {
         const name = res.additionalUserInfo.profile.name;
         const email = res.user.email;
-        const icon = res.user.photoURL;
+        const default_icon_url = res.user.photoURL;
         const token = res.user.Aa;
-        createUser(name, email, icon, token);
+        createUser(name, email, default_icon_url, token);
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {
@@ -78,7 +78,7 @@ const Login = () => {
       .then((res) => {
         const name = res.user.displayName;
         const email = res.user.email;
-        const icon = res.user.photoURL;
+        const default_icon_url = res.user.photoURL;
         const token = res.user.Aa;
         if (email === null) {
           auth.signOut();
@@ -87,7 +87,7 @@ const Login = () => {
           );
           return;
         }
-        createUser(name, email, icon, token);
+        createUser(name, email, default_icon_url, token);
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -27,7 +27,11 @@ const PostDetail = (props) => {
     axiosClient.get(`/posts/${id}`).then((res) => {
       setPost(res.data.post);
       setOwnerName(res.data.user.name);
-      setOwnerIconUrl(res.data.user.upload_icon.url ? res.data.user.upload_icon.url : res.data.user.default_icon_url);
+      setOwnerIconUrl(
+        res.data.user.upload_icon.url
+          ? res.data.user.upload_icon.url
+          : res.data.user.default_icon_url
+      );
       setCommentsAndUsers(res.data.comments_and_users);
     });
   }, []);

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -27,7 +27,7 @@ const PostDetail = (props) => {
     axiosClient.get(`/posts/${id}`).then((res) => {
       setPost(res.data.post);
       setOwnerName(res.data.user.name);
-      setOwnerIconUrl(res.data.user.icon.url);
+      setOwnerIconUrl(res.data.user.upload_icon.url ? res.data.user.upload_icon.url : res.data.user.default_icon_url);
       setCommentsAndUsers(res.data.comments_and_users);
     });
   }, []);

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -26,7 +26,7 @@ const Setting = () => {
       newInputValue.name = res.data.name;
       newInputValue.email = res.data.email;
       setInputValue(newInputValue);
-      setPreview(res.data.icon.url);
+      setPreview(res.data.upload_icon.url ? res.data.upload_icon.url : res.data.default_icon_url);
     });
   }, []);
 
@@ -34,7 +34,7 @@ const Setting = () => {
     const formData = new FormData();
     formData.append('user[name]', inputValue.name);
     formData.append('user[email]', inputValue.email);
-    if (icon) formData.append('user[icon]', icon);
+    if (icon) formData.append('user[upload_icon]', icon);
 
     axiosAuthClient
       .patch('/users/me', formData)

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -26,7 +26,11 @@ const Setting = () => {
       newInputValue.name = res.data.name;
       newInputValue.email = res.data.email;
       setInputValue(newInputValue);
-      setPreview(res.data.upload_icon.url ? res.data.upload_icon.url : res.data.default_icon_url);
+      setPreview(
+        res.data.upload_icon.url
+          ? res.data.upload_icon.url
+          : res.data.default_icon_url
+      );
     });
   }, []);
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:name) { |n| "test#{n}" }
     sequence(:email) { |n| "test#{n}@example.com" }
     sequence(:uid) { |n| "uid#{n}" }
+    sequence(:default_icon_url) { "https://nureyon.com/sample/8/upper_body-2-p2.svg?1601332163" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     sequence(:name) { |n| "test#{n}" }
     sequence(:email) { |n| "test#{n}@example.com" }
     sequence(:uid) { |n| "uid#{n}" }
-    sequence(:default_icon_url) { "https://nureyon.com/sample/8/upper_body-2-p2.svg?1601332163" }
+    sequence(:default_icon_url) { 'https://nureyon.com/sample/8/upper_body-2-p2.svg?1601332163' }
   end
 end


### PR DESCRIPTION
### 関連issue
#143 

### やったこと
- usersテーブルのiconカラムをupload_iconカラムに変更, default_icon_urlカラムに変更した
  upload_iconカラムには、設定画面でユーザーがアップロードしたアイコンが格納され、default_icon_urlカラムには、認証時にプロバイダーから取得したアイコン画像のURLが格納される
- アイコンの表示部分の修正
  upload_iconカラムにデータがある場合は、それを表示し、そうでない場合は、default_icon_urlカラムの画像を表示するという風にした

### UI

https://user-images.githubusercontent.com/61813626/143718687-001818c9-afb7-47c4-890d-81b4423b6768.mov

### 備考
Twitterのアイコンが小さすぎて、表示の時に画質がすごく悪い

### 参考
- [Rails カラム名変更方法](https://qiita.com/libertyu/items/93acd8733e34b1d0a63c)
- [条件演算子(?:)](https://www.javadrive.jp/ruby/if/index10.html)