### PR TITLE
ユーザー詳細ページの作成

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -29,7 +29,7 @@ module Api
         post.comments.includes(:user).each do |comment|
           user = comment.user
           user_icon_url = user.upload_icon.url || user.default_icon_url
-          comments_and_users.push({ comment: comment, user_name: user.name, user_icon_url: user_icon_url })
+          comments_and_users.push({ comment: comment, user_id: user.id, user_name: user.name, user_icon_url: user_icon_url })
         end
         render staus: :ok, json: { post: post, user: post.user, comments_and_users: comments_and_users }
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,16 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      skip_before_action :authenticate_user, only: :create
+      skip_before_action :authenticate_user, only: %i[show create]
+
+      def show
+        user = User.find(params[:id])
+        if user
+          render json: user, status: :ok
+        else
+          render status: :not_found
+        end
+      end
 
       def create
         FirebaseIdToken::Certificates.request

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      skip_before_action :authenticate_user, only: %i[show create]
+      skip_before_action :authenticate_user, only: %i[show create posts]
 
       def show
         user = User.find(params[:id])
@@ -48,6 +48,15 @@ module Api
         user = User.find_by(uid: params[:uid])
         if user
           render status: :ok, json: user
+        else
+          render status: :not_found
+        end
+      end
+
+      def posts
+        user = User.find(params[:id])
+        if user
+          render status: :ok, json: user.posts
         else
           render status: :not_found
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
         collection do
           get :search
         end
+        member do
+          get :posts
+        end
       end
       resources :posts, only: %i[index show create update destroy] do
         collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,13 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :users, only: :create do
+      get '/users/me', to: 'users#show_me'
+      patch '/users/me', to: 'users#update_me'
+      resources :users, only: %i[show create] do
         collection do
           get :search
         end
       end
-      get '/users/me', to: 'users#show_me'
-      patch '/users/me', to: 'users#update_me'
       resources :posts, only: %i[index show create update destroy] do
         collection do
           get :recent

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "react-md-spinner": "^1.0.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
+        "react-share": "^4.4.0",
         "react-simplemde-editor": "^5.0.2",
         "web-vitals": "^2.1.2"
       },
@@ -6744,6 +6745,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/clean-css": {
       "version": "4.2.3",
@@ -14195,6 +14201,27 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/jss": {
       "version": "10.8.0",
       "resolved": "https://registry.npmjs.org/jss/-/jss-10.8.0.tgz",
@@ -18104,6 +18131,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-share": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.4.0.tgz",
+      "integrity": "sha512-POe8Ge/JT9Ew9iyW7CiYsCCWCb8uMJWqFl9S7W0fJ/oH5gBJNzukH0bL5vSr17KKG5h15d3GfKaoviI22BKeYA==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "jsonp": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=6.9.0",
+        "npm": ">=5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17"
       }
     },
     "node_modules/react-simplemde-editor": {
@@ -28138,6 +28181,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -33892,6 +33940,29 @@
         "universalify": "^2.0.0"
       }
     },
+    "jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+      "requires": {
+        "debug": "^2.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "jss": {
       "version": "10.8.0",
       "resolved": "https://registry.npmjs.org/jss/-/jss-10.8.0.tgz",
@@ -37032,6 +37103,15 @@
         "webpack-dev-server": "3.11.1",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      }
+    },
+    "react-share": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.4.0.tgz",
+      "integrity": "sha512-POe8Ge/JT9Ew9iyW7CiYsCCWCb8uMJWqFl9S7W0fJ/oH5gBJNzukH0bL5vSr17KKG5h15d3GfKaoviI22BKeYA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "jsonp": "^0.2.1"
       }
     },
     "react-simplemde-editor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react-md-spinner": "^1.0.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-share": "^4.4.0",
     "react-simplemde-editor": "^5.0.2",
     "web-vitals": "^2.1.2"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import Login from './pages/Login';
 import PostList from './pages/PostList';
 import PostDetail from './pages/PostDetail';
 import Setting from './pages/Setting';
+import UserDetail from './pages/UserDetail';
 import PostForm from './pages/PostForm';
 import NotFound from './pages/NotFound';
 import Footer from './components/Footer';
@@ -65,6 +66,7 @@ const App = () => {
                   <PublicRoute path='/login' component={Login} />
                   <Route exact path='/posts' component={PostList} />
                   <PrivateRoute path='/setting' component={Setting} />
+                  <Route path='/users/:id' component={UserDetail} />
                   <PrivateRoute path='/posts/new' component={PostForm} />
                   <Route path='/posts/:id' component={PostDetail} />
                   <Route component={NotFound} />

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -37,6 +37,7 @@ const CommentList = (props) => {
           <Grid item xs={2} lg={1}>
             <div style={{ marginTop: 10 }}>
               <Owner
+                userId={commentAndUser.user_id}
                 userName={commentAndUser.user_name}
                 userIconUrl={commentAndUser.user_icon_url}
               />

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -11,7 +11,7 @@ const Owner = (props) => {
       textDecoration: 'none',
       '&:hover': {
         textDecoration: 'none',
-      }
+      },
     },
     icon: {
       border: 'solid 1px #bbb',

--- a/frontend/src/components/Owner.js
+++ b/frontend/src/components/Owner.js
@@ -1,11 +1,17 @@
+import Link from '@material-ui/core/Link';
 import { makeStyles } from '@material-ui/core/styles';
 
 const Owner = (props) => {
   const styles = makeStyles({
     owner: {
+      color: 'black',
       display: 'flex',
       flexDirection: 'column',
       textAlign: 'center',
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'none',
+      }
     },
     icon: {
       border: 'solid 1px #bbb',
@@ -22,10 +28,10 @@ const Owner = (props) => {
   const classes = styles();
 
   return (
-    <div className={classes.owner}>
+    <Link href={`/users/${props.userId}`} className={classes.owner}>
       <img src={props.userIconUrl} className={classes.icon} />
       <span className={classes.userName}>{props.userName}</span>
-    </div>
+    </Link>
   );
 };
 

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -74,7 +74,11 @@ const Post = (props) => {
     <Grid container>
       <Grid item xs={2}>
         <div style={{ marginTop: 10 }}>
-          <Owner userId={user.id} userName={userName} userIconUrl={userIconUrl} />
+          <Owner
+            userId={user.id}
+            userName={userName}
+            userIconUrl={userIconUrl}
+          />
         </div>
       </Grid>
       <Grid item xs={10} className={classes.postRight}>

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -74,7 +74,7 @@ const Post = (props) => {
     <Grid container>
       <Grid item xs={2}>
         <div style={{ marginTop: 10 }}>
-          <Owner userName={userName} userIconUrl={userIconUrl} />
+          <Owner userId={user.id} userName={userName} userIconUrl={userIconUrl} />
         </div>
       </Grid>
       <Grid item xs={10} className={classes.postRight}>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -16,6 +16,7 @@ const PostDetail = (props) => {
   const { params } = props.match;
   const id = parseInt(params.id, 10);
   const [post, setPost] = useState(null);
+  const [ownerId, setOwnerId] = useState(null);
   const [ownerName, setOwnerName] = useState('');
   const [ownerIconUrl, setOwnerIconUrl] = useState('');
   const [commentsAndUsers, setCommentsAndUsers] = useState(null);
@@ -26,6 +27,7 @@ const PostDetail = (props) => {
   useEffect(() => {
     axiosClient.get(`/posts/${id}`).then((res) => {
       setPost(res.data.post);
+      setOwnerId(res.data.user.id);
       setOwnerName(res.data.user.name);
       setOwnerIconUrl(
         res.data.user.upload_icon.url
@@ -112,7 +114,7 @@ const PostDetail = (props) => {
         <Grid container>
           <Grid item xs={2} lg={1}>
             <div style={{ marginTop: 20 }}>
-              <Owner userIconUrl={ownerIconUrl} userName={ownerName} />
+              <Owner userId={ownerId} userIconUrl={ownerIconUrl} userName={ownerName} />
             </div>
           </Grid>
           <Grid item xs={10} lg={11} className={classes.postDetailRight}>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -114,7 +114,11 @@ const PostDetail = (props) => {
         <Grid container>
           <Grid item xs={2} lg={1}>
             <div style={{ marginTop: 20 }}>
-              <Owner userId={ownerId} userIconUrl={ownerIconUrl} userName={ownerName} />
+              <Owner
+                userId={ownerId}
+                userIconUrl={ownerIconUrl}
+                userName={ownerName}
+              />
             </div>
           </Grid>
           <Grid item xs={10} lg={11} className={classes.postDetailRight}>

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -6,7 +6,7 @@ import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MDSpinner from 'react-md-spinner';
-import { TwitterIcon, TwitterShareButton, } from 'react-share';
+import { TwitterIcon, TwitterShareButton } from 'react-share';
 
 const UserDetail = (props) => {
   const { params } = props.match;
@@ -163,8 +163,18 @@ const UserDetail = (props) => {
       <Grid container>
         <Grid item xs={0} md={2} />
         <Grid item xs={12} md={8}>
-          <div style={{display: 'flex', justifyContent: 'flex-end', marginRight: 20, marginBottom: 20}}>
-            <TwitterShareButton url={`${process.env.REACT_APP_HOST_URL}/users/${user.id}`} title={`[ShareFolio] ${user.name}が作ったアプリ一覧`}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              marginRight: 20,
+              marginBottom: 20,
+            }}
+          >
+            <TwitterShareButton
+              url={`${process.env.REACT_APP_HOST_URL}/users/${user.id}`}
+              title={`[ShareFolio] ${user.name}が作ったアプリ一覧`}
+            >
               <TwitterIcon size={50} round={true} />
             </TwitterShareButton>
           </div>

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -118,33 +118,43 @@ const UserDetail = (props) => {
         <Grid item xs={0} md={2} />
         <Grid item xs={12} md={8}>
           <Grid container direction='column'>
-            <span style={{ fontSize: 25, marginLeft: 20, marginBottom: 20 }}>
-              作成したアプリ一覧
-            </span>
-            <Grid container>
-              {posts.map((post) => (
-                <Grid item xs={12} sm={12} md={6} key={post.id}>
-                  <Grid container>
-                    <Grid item xs={1} />
-                    <Grid item xs={10} className={classes.post}>
-                      <Link
-                        className={classes.appName}
-                        href={`/posts/${post.id}`}
-                      >
-                        {post.app_name}
-                      </Link>
-                      <Typography className={classes.description}>
-                        {previewDescription(post.description)}
-                      </Typography>
-                      <div className={classes.postFooter}>
-                        <CreatedAt createdAt={post.created_at} />
-                      </div>
+            {posts.length === 0 ? (
+              <span style={{ fontSize: 25, textAlign: 'center' }}>
+                作成したアプリはありません
+              </span>
+            ) : (
+              <>
+                <span
+                  style={{ fontSize: 25, marginLeft: 20, marginBottom: 20 }}
+                >
+                  作成したアプリ一覧
+                </span>
+                <Grid container>
+                  {posts.map((post) => (
+                    <Grid item xs={12} sm={12} md={6} key={post.id}>
+                      <Grid container>
+                        <Grid item xs={1} />
+                        <Grid item xs={10} className={classes.post}>
+                          <Link
+                            className={classes.appName}
+                            href={`/posts/${post.id}`}
+                          >
+                            {post.app_name}
+                          </Link>
+                          <Typography className={classes.description}>
+                            {previewDescription(post.description)}
+                          </Typography>
+                          <div className={classes.postFooter}>
+                            <CreatedAt createdAt={post.created_at} />
+                          </div>
+                        </Grid>
+                        <Grid item xs={1} />
+                      </Grid>
                     </Grid>
-                    <Grid item xs={1} />
-                  </Grid>
+                  ))}
                 </Grid>
-              ))}
-            </Grid>
+              </>
+            )}
           </Grid>
         </Grid>
         <Grid item xs={0} md={2} />

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -14,14 +14,12 @@ const UserDetail = (props) => {
   const [posts, setPosts] = useState(null);
 
   useEffect(() => {
-    axiosClient.get(`/users/${id}`)
-      .then(res => {
-        setUser(res.data);
-      });
-    axiosClient.get(`/users/${id}/posts`)
-      .then(res => {
-        setPosts(res.data);
-      })
+    axiosClient.get(`/users/${id}`).then((res) => {
+      setUser(res.data);
+    });
+    axiosClient.get(`/users/${id}/posts`).then((res) => {
+      setPosts(res.data);
+    });
   }, []);
 
   const previewDescription = (description) => {
@@ -79,24 +77,38 @@ const UserDetail = (props) => {
   const classes = styles();
   const isLoading = user === null || posts === null;
 
-  return isLoading ?
+  return isLoading ? (
     <div style={{ marginTop: 100, textAlign: 'center' }}>
       <MDSpinner size={70} />
     </div>
-    :
+  ) : (
     <div>
-      <Grid container alignItems='center' justifyContent='center' className={classes.user}>
+      <Grid
+        container
+        alignItems='center'
+        justifyContent='center'
+        className={classes.user}
+      >
         <Grid item xs={0} md={2} />
         <Grid item xs={12} md={4}>
           <Grid container alignItems='center' justifyContent='center'>
-            <img src={user.upload_icon.url ? user.upload_icon.url : user.default_icon_url} className={classes.icon} />
+            <img
+              src={
+                user.upload_icon.url
+                  ? user.upload_icon.url
+                  : user.default_icon_url
+              }
+              className={classes.icon}
+            />
           </Grid>
         </Grid>
         <Grid item xs={12} md={4}>
           <Grid container alignItems='center' justifyContent='center'>
-            <div style={{display: 'flex', flexDirection: 'column'}}>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
               <span className={classes.userName}>{user.name}</span>
-              <span className={classes.userItem}>{user.created_at.split('T')[0].substr(0, 10)}に登録</span>
+              <span className={classes.userItem}>
+                {user.created_at.split('T')[0].substr(0, 10)}に登録
+              </span>
             </div>
           </Grid>
         </Grid>
@@ -106,14 +118,19 @@ const UserDetail = (props) => {
         <Grid item xs={0} md={2} />
         <Grid item xs={12} md={8}>
           <Grid container direction='column'>
-            <span style={{fontSize: 25, marginLeft: 20, marginBottom: 20}}>作成したアプリ一覧</span>
+            <span style={{ fontSize: 25, marginLeft: 20, marginBottom: 20 }}>
+              作成したアプリ一覧
+            </span>
             <Grid container>
               {posts.map((post) => (
                 <Grid item xs={12} sm={12} md={6} key={post.id}>
                   <Grid container>
                     <Grid item xs={1} />
                     <Grid item xs={10} className={classes.post}>
-                      <Link className={classes.appName} href={`/posts/${post.id}`}>
+                      <Link
+                        className={classes.appName}
+                        href={`/posts/${post.id}`}
+                      >
                         {post.app_name}
                       </Link>
                       <Typography className={classes.description}>
@@ -125,15 +142,15 @@ const UserDetail = (props) => {
                     </Grid>
                     <Grid item xs={1} />
                   </Grid>
-                </Grid>)
-              )}
+                </Grid>
+              ))}
             </Grid>
           </Grid>
         </Grid>
         <Grid item xs={0} md={2} />
       </Grid>
     </div>
-  ;
-}
+  );
+};
 
 export default UserDetail;

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -1,21 +1,139 @@
+import React, { useState, useEffect } from 'react';
+import { axiosClient } from '../api/axiosClient';
+import CreatedAt from '../components/CreatedAt';
+import Grid from '@material-ui/core/Grid';
+import Link from '@material-ui/core/Link';
+import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
+import MDSpinner from 'react-md-spinner';
 
 const UserDetail = (props) => {
   const { params } = props.match;
   const id = parseInt(params.id, 10);
+  const [user, setUser] = useState(null);
+  const [posts, setPosts] = useState(null);
+
+  useEffect(() => {
+    axiosClient.get(`/users/${id}`)
+      .then(res => {
+        setUser(res.data);
+      });
+    axiosClient.get(`/users/${id}/posts`)
+      .then(res => {
+        setPosts(res.data);
+      })
+  }, []);
+
+  const previewDescription = (description) => {
+    let result = '';
+    for (let i = 0; i < description.length; i++) {
+      const c = description[i];
+      if (c == ' ' || c == '#') continue;
+      result += c;
+      if (result.length > 150) {
+        result += '...';
+        break;
+      }
+    }
+    return result;
+  };
+
   const styles = makeStyles({
     user: {
-      paddingTop: 150,
-    }
+      paddingTop: 100,
+    },
+    icon: {
+      border: 'solid 1px #bbb',
+      borderRadius: '50%',
+      height: 300,
+      width: 300,
+    },
+    userName: {
+      fontSize: 30,
+    },
+    userItem: {
+      fontSize: 20,
+    },
+    post: {
+      border: 'solid 1px #bbb',
+      borderRadius: '10px',
+      marginBottom: 20,
+      padding: 10,
+    },
+    appName: {
+      fontSize: 30,
+      textDecoration: 'none',
+    },
+    description: {
+      fontSize: 15,
+      overflowWrap: 'break-word',
+      borderBottom: '1px solid #bbb',
+    },
+    postFooter: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: 5,
+    },
   });
 
   const classes = styles();
+  const isLoading = user === null || posts === null;
 
-  return (
-    <div className={classes.user}>
-      <h1>User{id}</h1>
+  return isLoading ?
+    <div style={{ marginTop: 100, textAlign: 'center' }}>
+      <MDSpinner size={70} />
     </div>
-  );
+    :
+    <div>
+      <Grid container alignItems='center' justifyContent='center' className={classes.user}>
+        <Grid item xs={0} md={2} />
+        <Grid item xs={12} md={4}>
+          <Grid container alignItems='center' justifyContent='center'>
+            <img src={user.upload_icon.url ? user.upload_icon.url : user.default_icon_url} className={classes.icon} />
+          </Grid>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Grid container alignItems='center' justifyContent='center'>
+            <div style={{display: 'flex', flexDirection: 'column'}}>
+              <span className={classes.userName}>{user.name}</span>
+              <span className={classes.userItem}>{user.created_at.split('T')[0].substr(0, 10)}に登録</span>
+            </div>
+          </Grid>
+        </Grid>
+        <Grid item xs={0} md={2} />
+      </Grid>
+      <Grid container style={{ marginTop: 30 }}>
+        <Grid item xs={0} md={2} />
+        <Grid item xs={12} md={8}>
+          <Grid container direction='column'>
+            <span style={{fontSize: 25, marginLeft: 20, marginBottom: 20}}>作成したアプリ一覧</span>
+            <Grid container>
+              {posts.map((post) => (
+                <Grid item xs={12} sm={12} md={6} key={post.id}>
+                  <Grid container>
+                    <Grid item xs={1} />
+                    <Grid item xs={10} className={classes.post}>
+                      <Link className={classes.appName} href={`/posts/${post.id}`}>
+                        {post.app_name}
+                      </Link>
+                      <Typography className={classes.description}>
+                        {previewDescription(post.description)}
+                      </Typography>
+                      <div className={classes.postFooter}>
+                        <CreatedAt createdAt={post.created_at} />
+                      </div>
+                    </Grid>
+                    <Grid item xs={1} />
+                  </Grid>
+                </Grid>)
+              )}
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={0} md={2} />
+      </Grid>
+    </div>
+  ;
 }
 
 export default UserDetail;

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -6,6 +6,7 @@ import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MDSpinner from 'react-md-spinner';
+import { TwitterIcon, TwitterShareButton, } from 'react-share';
 
 const UserDetail = (props) => {
   const { params } = props.match;
@@ -156,6 +157,17 @@ const UserDetail = (props) => {
               </>
             )}
           </Grid>
+        </Grid>
+        <Grid item xs={0} md={2} />
+      </Grid>
+      <Grid container>
+        <Grid item xs={0} md={2} />
+        <Grid item xs={12} md={8}>
+          <div style={{display: 'flex', justifyContent: 'flex-end', marginRight: 20, marginBottom: 20}}>
+            <TwitterShareButton url={`${process.env.REACT_APP_HOST_URL}/users/${user.id}`} title={`[ShareFolio] ${user.name}が作ったアプリ一覧`}>
+              <TwitterIcon size={50} round={true} />
+            </TwitterShareButton>
+          </div>
         </Grid>
         <Grid item xs={0} md={2} />
       </Grid>

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -1,0 +1,21 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const UserDetail = (props) => {
+  const { params } = props.match;
+  const id = parseInt(params.id, 10);
+  const styles = makeStyles({
+    user: {
+      paddingTop: 150,
+    }
+  });
+
+  const classes = styles();
+
+  return (
+    <div className={classes.user}>
+      <h1>User{id}</h1>
+    </div>
+  );
+}
+
+export default UserDetail;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4008,6 +4008,11 @@
     "isobject" "^3.0.0"
     "static-extend" "^0.1.1"
 
+"classnames@^2.2.5":
+  "integrity" "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+  "resolved" "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
+  "version" "2.3.1"
+
 "clean-css@^4.2.3":
   "integrity" "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA=="
   "resolved" "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz"
@@ -4736,6 +4741,13 @@
     "abab" "^2.0.3"
     "whatwg-mimetype" "^2.3.0"
     "whatwg-url" "^8.0.0"
+
+"debug@^2.1.3":
+  "integrity" "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+  "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  "version" "2.6.9"
+  dependencies:
+    "ms" "2.0.0"
 
 "debug@^2.2.0":
   "integrity" "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
@@ -7799,6 +7811,13 @@
   optionalDependencies:
     "graceful-fs" "^4.1.6"
 
+"jsonp@^0.2.1":
+  "integrity" "sha1-pltPoPEL2nGaBUQep7lMVfPhW64="
+  "resolved" "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz"
+  "version" "0.2.1"
+  dependencies:
+    "debug" "^2.1.3"
+
 "jss-plugin-camel-case@^10.5.1":
   "integrity" "sha512-yxlXrXwcCdGw+H4BC187dEu/RFyW8joMcWfj8Rk9UPgWTKu2Xh7Sib4iW3xXjHe/t5phOHF1rBsHleHykWix7g=="
   "resolved" "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.8.0.tgz"
@@ -10411,6 +10430,14 @@
   optionalDependencies:
     "fsevents" "^2.1.3"
 
+"react-share@^4.4.0":
+  "integrity" "sha512-POe8Ge/JT9Ew9iyW7CiYsCCWCb8uMJWqFl9S7W0fJ/oH5gBJNzukH0bL5vSr17KKG5h15d3GfKaoviI22BKeYA=="
+  "resolved" "https://registry.npmjs.org/react-share/-/react-share-4.4.0.tgz"
+  "version" "4.4.0"
+  dependencies:
+    "classnames" "^2.2.5"
+    "jsonp" "^0.2.1"
+
 "react-simplemde-editor@^5.0.2":
   "integrity" "sha512-yaqZSaUBf6B0kQY0mH8WP/nHnvJFz48aO8cMYCL1e/AFiuB/H8UDuyZFP9/exOtwVpaG373HYR1YedKMtCh+Kw=="
   "resolved" "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-5.0.2.tgz"
@@ -10429,7 +10456,7 @@
     "loose-envify" "^1.4.0"
     "prop-types" "^15.6.2"
 
-"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0", "react@^17.0.2", "react@>= 16", "react@>=15", "react@>=16.3.0", "react@>=16.6.0", "react@>=16.8.0", "react@>=16.8.2", "react@17.0.2":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^16.3.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^17.0.2", "react@>= 16", "react@>=15", "react@>=16.3.0", "react@>=16.6.0", "react@>=16.8.0", "react@>=16.8.2", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"


### PR DESCRIPTION
### 関連issue
#132 

### やったこと
- GET /users/:id を作成
- GET /users/:id/posts を作成
  ユーザーの投稿一覧を取得する
- ユーザーの詳細画面の作成
  アイコン画像、ユーザー名、登録日、投稿一覧、ツイッター共有ボタンを表示した ツイッター共有ボタンはreact-shareを使った
  他にも、GitHubのリンクやTwitterのリンクを設置したい
  URLは/users/:id となっている よく、/users/:nameを見る気がするが、今回はユーザー名が一意ではないので、この方法にはできない

### UI
投稿が1件もない場合
<img width="800" alt="スクリーンショット 2021-11-29 15 28 09" src="https://user-images.githubusercontent.com/61813626/143819202-3d9d9b99-3429-4ae8-9e23-e327b4d7cb89.png">

投稿が複数ある場合
<img width="800" alt="スクリーンショット 2021-11-29 15 27 53" src="https://user-images.githubusercontent.com/61813626/143819165-a0f95544-6fa1-40a4-8d8a-f75c0656302f.png">

### 備考
- Herokuの環境変数に`REACT_APP_HOST_URL`を設定する
- 投稿の表示はPostコンポーネントを使えると思ったが、左のアイコンはいらないので、UserDetailの中で再度実装するような形になってしまった フロントもサーバーも全体的にコードがぐちゃぐちゃになってきているので、一度見直した方が良さそう

### 参考
- [ReactでSNSシェア機能をreact-shareというライブラリで](https://tech.motoki-watanabe.net/entry/2020/12/29/182738)
- [nygardk/react-share](https://github.com/nygardk/react-share)
- [react-shareで簡単にSNSシェアボタン](https://makimono.ninja/react-share/)
