### PR TITLE
GET /posts をページネーションに対応させた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "factory_bot_rails"
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'firebase-auth-rails'
+gem 'kaminari'
 
 group :development, :test do
   gem 'sqlite3', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,18 @@ GEM
     ipaddress (0.8.3)
     json (2.6.0)
     jwt (2.3.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -480,6 +492,7 @@ DEPENDENCIES
   factory_bot_rails
   firebase-auth-rails
   fog
+  kaminari
   listen (~> 3.3)
   mini_magick
   pg

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -14,7 +14,7 @@ module Api
         posts.each do |post|
           posts_and_users.push({ post: post, user: post.user })
         end
-        render status: :ok, json: {posts_and_users: posts_and_users}.merge(pagination)
+        render status: :ok, json: { posts_and_users: posts_and_users }.merge(pagination)
       end
 
       def recent

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -4,14 +4,17 @@ module Api
   module V1
     class PostsController < ApplicationController
       skip_before_action :authenticate_user, only: %i[index recent show]
+      include Pagination
 
       def index
         posts = Post.all.includes(:user).order(:id)
+        posts = posts.page(params[:page]).per(params[:per])
+        pagination = pagination(posts)
         posts_and_users = []
         posts.each do |post|
           posts_and_users.push({ post: post, user: post.user })
         end
-        render status: :ok, json: posts_and_users
+        render status: :ok, json: {posts_and_users: posts_and_users}.merge(pagination)
       end
 
       def recent

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,0 +1,11 @@
+module Pagination
+  def pagination(records)
+    {
+      pagination: {
+        current_page: records.current_page,
+        total_count: records.total_count,
+        total_pages: records.total_pages,
+      }
+    }
+  end
+end

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pagination
   def pagination(records)
     {
@@ -5,7 +7,7 @@ module Pagination
         current_page: records.current_page,
         total_count: records.total_count,
         total_pages: records.total_pages,
-      }
+      },
     }
   end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -8,9 +8,12 @@ RSpec.describe '/api/v1/posts', type: :request do
   describe 'index' do
     it 'accept an auth user' do
       create_list(:post, 10)
-      get '/api/v1/posts', headers: xhr_header
+      get '/api/v1/posts?page=1&per=6', headers: xhr_header
       expect(response.status).to eq(200)
-      expect(json(response).length).to eq(10)
+      expect(json(response)['posts_and_users'].length).to eq(6)
+      get '/api/v1/posts?page=2&per=6', headers: xhr_header
+      expect(response.status).to eq(200)
+      expect(json(response)['posts_and_users'].length).to eq(4)
     end
 
     it 'accept an unauth user' do


### PR DESCRIPTION
### 関連issue
#150 

### やったこと
- GET /posts をページネーションに対応させた

### 備考
Postmanで動作確認
<img width="387" alt="スクリーンショット 2021-12-04 21 27 56" src="https://user-images.githubusercontent.com/61813626/144709364-d0754fcf-235b-4e02-89ba-69bace2afde8.png">

### 参考
- [RailsAPIでページネーションに対応したJSONを返す(kaminari使用)](https://qiita.com/wonder_meet/items/33f6a257d94346c7e476)
- [Rails APIモードで kaminari を使ってみる](https://kossy-web-engineer.hatenablog.com/entry/2021/07/18/123404)
- [rails concernの使い方](https://lanlib.com/2021/04/04/rails-concern%e3%81%ae%e4%bd%bf%e3%81%84%e6%96%b9/)
- [取得するデータの数と開始位置を指定(LIMIT句, OFFSET句)](https://www.dbonline.jp/sqlite/select/index10.html)
