### PR TITLE
いいね機能のバックエンド実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,7 +41,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'config/sitemap.rb'
-    - 'config/routes/**'
+    - 'config/routes.rb'
     - 'factories/**/*'
     - 'spec/**/*'
     - 'config/environments/*'

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -24,7 +24,7 @@ module Api
         end
       end
 
-      def is_liked
+      def liked?
         post_id = params[:id]
         like = Like.find_by(user_id: current_user.id, post_id: post_id)
         if like

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class LikesController < ApplicationController
+      def create
+        post_id = params[:post_id]
+        like = current_user.likes.build(post_id: post_id)
+        if like.save
+          render status: :created, json: like
+        else
+          render status: :bad_request
+        end
+      end
+
+      def destroy
+        post_id = params[:post_id]
+        like = Like.find_by(user_id: current_user.id, post_id: post_id)
+        if like
+          like.destroy
+          render status: :no_content
+        else
+          render :not_found
+        end
+      end
+
+      def is_liked
+        post_id = params[:id]
+        like = Like.find_by(user_id: current_user.id, post_id: post_id)
+        if like
+          render status: :ok, json: { flag: true }
+        else
+          render status: :ok, json: { flag: false }
+        end
+      end
+    end
+  end
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   validates :app_name, presence: true, length: { maximum: 50 }
   validates :app_url, presence: true, length: { maximum: 255 }
   validates :repo_url, length: { maximum: 255 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,5 @@ class Post < ApplicationRecord
   validates :app_url, presence: true, length: { maximum: 255 }
   validates :repo_url, length: { maximum: 255 }
   validates :description, presence: true, length: { maximum: 10000 }
+  validates :like_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   validates :name, { presence: true, length: { minimum: 3, maximum: 20 } }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   validates :email, {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,14 @@ Rails.application.routes.draw do
           get :recent
         end
         resources :comments, only: [:create]
+        resources :likes, only: [:create] do
+          collection do
+            delete '', to: 'likes#destroy'
+          end
+        end
+        member do
+          get '/is_liked', to: 'likes#is_liked'
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
           end
         end
         member do
-          get '/is_liked', to: 'likes#is_liked'
+          get '/is_liked', to: 'likes#liked?'
         end
       end
     end

--- a/db/migrate/20211206100149_create_likes.rb
+++ b/db/migrate/20211206100149_create_likes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLikes < ActiveRecord::Migration[6.1]
   def change
     create_table :likes do |t|
@@ -5,6 +7,6 @@ class CreateLikes < ActiveRecord::Migration[6.1]
       t.references :post, foreign_key: true, null: false
       t.timestamps
     end
-    add_index :likes, [:user_id, :post_id], unique: true
+    add_index :likes, %i[user_id post_id], unique: true
   end
 end

--- a/db/migrate/20211206100149_create_likes.rb
+++ b/db/migrate/20211206100149_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :post, foreign_key: true, null: false
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :post_id], unique: true
+  end
+end

--- a/db/migrate/20211206111101_add_like_num_to_posts.rb
+++ b/db/migrate/20211206111101_add_like_num_to_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLikeNumToPosts < ActiveRecord::Migration[6.1]
   def change
     change_table :posts do |t|

--- a/db/migrate/20211206111101_add_like_num_to_posts.rb
+++ b/db/migrate/20211206111101_add_like_num_to_posts.rb
@@ -1,0 +1,7 @@
+class AddLikeNumToPosts < ActiveRecord::Migration[6.1]
+  def change
+    change_table :posts do |t|
+      t.integer :like_num, null: false, default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_06_100149) do
+ActiveRecord::Schema.define(version: 2021_12_06_111101) do
 
   create_table "comments", force: :cascade do |t|
     t.string "content", null: false
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2021_12_06_100149) do
     t.string "app_url", null: false
     t.string "repo_url"
     t.text "description", null: false
+    t.integer "like_num", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_175204) do
+ActiveRecord::Schema.define(version: 2021_12_06_100149) do
 
   create_table "comments", force: :cascade do |t|
     t.string "content", null: false
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 2021_11_27_175204) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -47,5 +57,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_175204) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :like do
+    association :user
+    association :post
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     sequence(:repo_url) { |n| "https://example.com/repo#{n}" }
     sequence(:description) { |n| "description#{n}" * 100 }
     sequence(:user_id) { 1 }
+    sequence(:like_num) { |n| n }
   end
 end

--- a/spec/models/likes_spec.rb
+++ b/spec/models/likes_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Like, type: :model do
     user = like.user
     expect do
       user.destroy
-    end.to change(Like, :count).by(-1)
+    end.to change(described_class, :count).by(-1)
   end
 
   it 'is deleted when a corresponding post is deleted' do
     post = like.post
     expect do
       post.destroy
-    end.to change(Like, :count).by(-1)
+    end.to change(described_class, :count).by(-1)
   end
 end

--- a/spec/models/likes_spec.rb
+++ b/spec/models/likes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  let(:like) { create(:like) }
+
+  it 'is valid' do
+    expect(like).to be_valid
+  end
+
+  it 'is deleted when a corresponding user is deleted' do
+    user = like.user
+    expect do
+      user.destroy
+    end.to change(Like, :count).by(-1)
+  end
+
+  it 'is deleted when a corresponding post is deleted' do
+    post = like.post
+    expect do
+      post.destroy
+    end.to change(Like, :count).by(-1)
+  end
+end

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Post, type: :model do
     expect(post).to be_invalid
   end
 
+  it 'is invalid with a float like_num' do
+    post = build(:post, like_num: 1.23)
+    expect(post).to be_invalid
+  end
+
+  it 'is invalid with a minus like_num' do
+    post = build(:post, like_num: -1)
+    expect(post).to be_invalid
+  end
+
   it 'is invalid with a too long description' do
     post = build(:post, description: 'a' * 10001)
     expect(post).to be_invalid


### PR DESCRIPTION
### 関連issue
#156 

### やったこと
- likesテーブルの作成
- Likeモデルの設定
  アソシエーションの設定 & 対応するユーザー、投稿が削除されたら、いいねも削除されるように設定
- Likeモデルのテスト作成
- postsテーブルにlike_numカラムを追加
  /app/models/post.rbで、like_numカラムのバリデーション(整数であること、0以上であること)を設定している
- いいね関連のAPIを実装
  POST /posts/:post_id/likes いいねする
  DELETE /posts/:post_id/likes いいね取り消し
  GET /posts/:id/is_like いいねしているかのフラグを取得
  Postmanでの動作確認済み
  トークンはコンソールで確認して、PostmanのAuthのところにセットする(TypeはBearer Token)

### 備考
- 関係ないけど、マイグレーションファイルの`limit`が最大値の設定だとこれまで勘違いしていたことが判明した(正しくは最大バイト数の指定)
- 今更気づいたが、マイグレーションファイルの`t.timestamps`によって、created_atとupdated_atが作成されている

### 参考
- [migrationで複数カラムのindexを生成する時の注意事項](https://gutch.hatenablog.com/entry/20120222/1329890161)
- [データベースにindexを張る方法](https://qiita.com/seiya1121/items/fb074d727c6f40a55f22)
- [【Rails】複数のカラムを使ったユニーク制約の方法【uniqueness: scope】](https://310nae.com/rails-uniqueness/)
- [FactoryBotにおけるcreateとbuildの違い](https://qiita.com/takutotacos/items/4a8bd25ccb42141bf67c)
- [RailsチュートリアルのテストをRspecで書いてみた[第13章]](https://matazoukun.hatenablog.com/entry/2020/10/08/184915)
- [RSpecのbeforeでインスタンス変数を使いたくなったら、letを使うことを考えたほうがよさそう](https://shinkufencer.hateblo.jp/entry/2019/02/01/233000)
- [テーブル定義を変更](https://railsdoc.com/page/change_table)
- [Active Record バリデーション](https://railsguides.jp/active_record_validations.html#numericality)
- [Rails — マイグレーションで integer カラムを作る時の :limit は、桁数指定ではない ( バイト数指定だ )](https://qiita.com/Yinaura/items/cede8324d08993d2065c)
- [Rails 一意性制約のかけ方](https://note.com/norio1629/n/ne604267e36fd)