### PR TITLE
フロント側でいいねできるようにする

### DIFF
--- a/frontend/src/components/Like.js
+++ b/frontend/src/components/Like.js
@@ -7,16 +7,16 @@ const Like = (props) => {
       {props.likeFlag ? (
         <div onClick={props.destroyLike}>
           <FavoriteIcon
-            style={{ color: 'red', fontSize: 30, verticalAlign: 'middle' }}
+            style={{ color: 'red', fontSize: props.heartSize, verticalAlign: 'middle' }}
           />
-          <span style={{ fontSize: 25, verticalAlign: 'middle' }}>
+          <span style={{ fontSize: props.numSize, verticalAlign: 'middle' }}>
             {props.likeNum}
           </span>
         </div>
       ) : (
         <div onClick={props.createLike}>
-          <FavoriteBorderIcon style={{ fontSize: 30, verticalAlign: 'middle' }} />
-          <span style={{ fontSize: 25, verticalAlign: 'middle' }}>
+          <FavoriteBorderIcon style={{ fontSize: props.heartSize, verticalAlign: 'middle' }} />
+          <span style={{ fontSize: props.numSize, verticalAlign: 'middle' }}>
             {props.likeNum}
           </span>
         </div>

--- a/frontend/src/components/Like.js
+++ b/frontend/src/components/Like.js
@@ -1,4 +1,5 @@
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 const Like = (props) => {
   return (
@@ -14,7 +15,7 @@ const Like = (props) => {
         </div>
       ) : (
         <div onClick={props.createLike}>
-          <FavoriteIcon style={{ fontSize: 30, verticalAlign: 'middle' }} />
+          <FavoriteBorderIcon style={{ fontSize: 30, verticalAlign: 'middle' }} />
           <span style={{ fontSize: 25, verticalAlign: 'middle' }}>
             {props.likeNum}
           </span>

--- a/frontend/src/components/Like.js
+++ b/frontend/src/components/Like.js
@@ -1,0 +1,27 @@
+import FavoriteIcon from '@mui/icons-material/Favorite';
+
+const Like = (props) => {
+  return (
+    <>
+      {props.likeFlag ? (
+        <div onClick={props.destroyLike}>
+          <FavoriteIcon
+            style={{ color: 'red', fontSize: 30, verticalAlign: 'middle' }}
+          />
+          <span style={{ fontSize: 25, verticalAlign: 'middle' }}>
+            {props.likeNum}
+          </span>
+        </div>
+      ) : (
+        <div onClick={props.createLike}>
+          <FavoriteIcon style={{ fontSize: 30, verticalAlign: 'middle' }} />
+          <span style={{ fontSize: 25, verticalAlign: 'middle' }}>
+            {props.likeNum}
+          </span>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default Like;

--- a/frontend/src/components/Like.js
+++ b/frontend/src/components/Like.js
@@ -7,7 +7,11 @@ const Like = (props) => {
       {props.likeFlag ? (
         <div onClick={props.destroyLike}>
           <FavoriteIcon
-            style={{ color: 'red', fontSize: props.heartSize, verticalAlign: 'middle' }}
+            style={{
+              color: 'red',
+              fontSize: props.heartSize,
+              verticalAlign: 'middle',
+            }}
           />
           <span style={{ fontSize: props.numSize, verticalAlign: 'middle' }}>
             {props.likeNum}
@@ -15,7 +19,9 @@ const Like = (props) => {
         </div>
       ) : (
         <div onClick={props.createLike}>
-          <FavoriteBorderIcon style={{ fontSize: props.heartSize, verticalAlign: 'middle' }} />
+          <FavoriteBorderIcon
+            style={{ fontSize: props.heartSize, verticalAlign: 'middle' }}
+          />
           <span style={{ fontSize: props.numSize, verticalAlign: 'middle' }}>
             {props.likeNum}
           </span>

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -97,7 +97,9 @@ const Post = (props) => {
           <div className={classes.like}>
             <Like
               likeNum={post.like_num}
+              numSize={20}
               likeFlag={props.likeFlag}
+              heartSize={25}
               createLike={() => {}}
               destroyLike={() => {}}
             />

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -97,7 +97,7 @@ const Post = (props) => {
           <div className={classes.like}>
             <Like
               likeNum={post.like_num}
-              likeFlag={false}
+              likeFlag={props.likeFlag}
               createLike={() => {}}
               destroyLike={() => {}}
             />

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -1,5 +1,6 @@
 import Owner from './Owner';
 import CreatedAt from './CreatedAt';
+import Like from './Like';
 import Grid from '@material-ui/core/Grid';
 import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
@@ -36,9 +37,16 @@ const Post = (props) => {
       borderRadius: '10px',
       padding: 10,
     },
+    appNameAndLike: {
+      alignItems: 'center',
+      display: 'flex',
+    },
     appName: {
       fontSize: 30,
       textDecoration: 'none',
+    },
+    like: {
+      marginLeft: 'auto',
     },
     description: {
       fontSize: 15,
@@ -82,9 +90,19 @@ const Post = (props) => {
         </div>
       </Grid>
       <Grid item xs={10} className={classes.postRight}>
-        <Link className={classes.appName} href={`/posts/${post.id}`}>
-          {appName}
-        </Link>
+        <div className={classes.appNameAndLike}>
+          <Link className={classes.appName} href={`/posts/${post.id}`}>
+            {appName}
+          </Link>
+          <div className={classes.like}>
+            <Like
+              likeNum={post.like_num}
+              likeFlag={false}
+              createLike={() => {}}
+              destroyLike={() => {}}
+            />
+          </div>
+        </div>
         <Typography className={classes.description}>
           {previewDescription(description)}
         </Typography>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -10,6 +10,7 @@ import Owner from '../components/Owner';
 import CommentForm from '../components/CommentForm';
 import CreatedAt from '../components/CreatedAt';
 import CommentList from '../components/CommentList';
+import Like from '../components/Like';
 import MDSpinner from 'react-md-spinner';
 
 const PostDetail = (props) => {
@@ -23,6 +24,8 @@ const PostDetail = (props) => {
   const userName = useContext(AuthContext).userName;
   const userIconUrl = useContext(AuthContext).userIconUrl;
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
+  const [likeNum, setLikeNum] = useState(null);
+  const [likeFlag, setLikeFlag] = useState(null);
 
   useEffect(() => {
     axiosClient.get(`/posts/${id}`).then((res) => {
@@ -35,6 +38,11 @@ const PostDetail = (props) => {
           : res.data.user.default_icon_url
       );
       setCommentsAndUsers(res.data.comments_and_users);
+      setLikeNum(res.data.post.like_num);
+    });
+
+    axiosAuthClient.get(`/posts/${id}/is_liked`).then((res) => {
+      setLikeFlag(res.data.flag);
     });
   }, []);
 
@@ -51,6 +59,18 @@ const PostDetail = (props) => {
         setCommentsAndUsers(newCommentsAndUsers);
         updateFlashMessage({ successMessage: 'コメントをつけました' });
       });
+  };
+
+  const createLike = () => {
+    setLikeFlag(true);
+    setLikeNum(likeNum + 1);
+    axiosAuthClient.post(`/posts/${id}/likes`);
+  };
+
+  const destroyLike = () => {
+    setLikeFlag(false);
+    setLikeNum(likeNum - 1);
+    axiosAuthClient.delete(`/posts/${id}/likes`);
   };
 
   const styles = makeStyles({
@@ -101,7 +121,9 @@ const PostDetail = (props) => {
     post === null ||
     ownerName === null ||
     ownerIconUrl === '' ||
-    commentsAndUsers === null;
+    commentsAndUsers === null ||
+    likeNum === null ||
+    likeFlag === null;
 
   return isLoading ? (
     <div style={{ marginTop: 100, textAlign: 'center' }}>
@@ -149,6 +171,12 @@ const PostDetail = (props) => {
             </div>
           </Grid>
         </Grid>
+        <Like
+          likeNum={likeNum}
+          likeFlag={likeFlag}
+          createLike={createLike}
+          destroyLike={destroyLike}
+        />
         <div style={{ marginTop: 50 }}>
           <CommentForm submitComment={submitComment} />
         </div>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -160,7 +160,9 @@ const PostDetail = (props) => {
                 <div className={classes.like}>
                   <Like
                     likeNum={likeNum}
+                    numSize={25}
                     likeFlag={likeFlag}
+                    heartSize={30}
                     createLike={createLike}
                     destroyLike={destroyLike}
                   />

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -98,9 +98,12 @@ const PostDetail = (props) => {
       paddingBottom: 20,
       borderBottom: 'solid 1px #bbb',
     },
-    appName: {
-      display: 'inline-block',
-      verticalAlign: 'middle',
+    appNameAndLike: {
+      alignItems: 'center',
+      display: 'flex',
+    },
+    like: {
+      marginLeft: 'auto',
     },
     link: {
       overflowWrap: 'break-word',
@@ -145,7 +148,17 @@ const PostDetail = (props) => {
           </Grid>
           <Grid item xs={10} lg={11} className={classes.postDetailRight}>
             <div className={classes.postDetailRightHeader}>
-              <h1 className={classes.appName}>{post.app_name}</h1> <br />
+              <div className={classes.appNameAndLike}>
+                <h1>{post.app_name}</h1>
+                <div className={classes.like}>
+                  <Like
+                    likeNum={likeNum}
+                    likeFlag={likeFlag}
+                    createLike={createLike}
+                    destroyLike={destroyLike}
+                  />
+                </div>
+              </div>
               アプリ:{' '}
               <a href={post.app_url} className={classes.link}>
                 {post.app_url}
@@ -171,12 +184,6 @@ const PostDetail = (props) => {
             </div>
           </Grid>
         </Grid>
-        <Like
-          likeNum={likeNum}
-          likeFlag={likeFlag}
-          createLike={createLike}
-          destroyLike={destroyLike}
-        />
         <div style={{ marginTop: 50 }}>
           <CommentForm submitComment={submitComment} />
         </div>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -23,6 +23,7 @@ const PostDetail = (props) => {
   const [commentsAndUsers, setCommentsAndUsers] = useState(null);
   const userName = useContext(AuthContext).userName;
   const userIconUrl = useContext(AuthContext).userIconUrl;
+  const loggedIn = useContext(AuthContext).loggedIn;
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const [likeNum, setLikeNum] = useState(null);
   const [likeFlag, setLikeFlag] = useState(null);
@@ -41,9 +42,13 @@ const PostDetail = (props) => {
       setLikeNum(res.data.post.like_num);
     });
 
-    axiosAuthClient.get(`/posts/${id}/is_liked`).then((res) => {
-      setLikeFlag(res.data.flag);
-    });
+    if (loggedIn) {
+      axiosAuthClient.get(`/posts/${id}/is_liked`).then((res) => {
+        setLikeFlag(res.data.flag);
+      });
+    } else {
+      setLikeFlag(false);
+    }
   }, []);
 
   const submitComment = async (markdown) => {
@@ -62,12 +67,14 @@ const PostDetail = (props) => {
   };
 
   const createLike = () => {
+    if (!loggedIn) return;
     setLikeFlag(true);
     setLikeNum(likeNum + 1);
     axiosAuthClient.post(`/posts/${id}/likes`);
   };
 
   const destroyLike = () => {
+    if (!loggedIn) return;
     setLikeFlag(false);
     setLikeNum(likeNum - 1);
     axiosAuthClient.delete(`/posts/${id}/likes`);


### PR DESCRIPTION
### 関連issue
#156 

### やったこと
- Likeコンポーネントの作成
  propsとして、`createLike`(いいね時に実行される関数)、`destroyLike`(いいね解除時に実行される関数)、`likeNum`(いいね数)、`heartSize`(ハートのフォントサイズ)、`numSize`(いいね数のフォントサイズ)を受け取る
- Likeコンポーネントを配置
  投稿詳細、投稿一覧、ユーザー詳細画面に配置している
  投稿詳細画面から、いいねを押すことができる(未ログインユーザーは押せない)
  QiitaのLGTMの仕様を参考にした

### UI

https://user-images.githubusercontent.com/61813626/144972412-4ce3b5f6-bb60-497d-842d-ba6e8d3e2837.mov

### 参考
- [CSSで要素を右寄せする方法の全て｜文字も画像も右寄せにしよう](https://www.sejuku.net/blog/72034)
- [JSのスプレッド構文を理解する](https://qiita.com/akisx/items/682a4283c13fe336c547)
- [Array.prototype.map()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/map)
- [JavaScriptの配列初期化](https://qiita.com/yuta-ike/items/f60b940540a89332df2a)
- [JavaScriptの配列のmapでasync/awaitを使う方法](https://qiita.com/kwbt/items/6c0fe424c89a9f7553c1)
- [new PromiseとPromise.resolveの違い](https://qiita.com/ueokande/items/807a6c9a64c3874a0f83)
- [Promise.all() - 複数のPromise関数を実行し、全ての結果を得る](https://lab.syncer.jp/Web/JavaScript/Reference/Global_Object/Promise/all/)
