### PR TITLE
Twitterアカウント、GitHubアカウントを設定できるようにした

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -70,6 +70,8 @@ module Api
           :email,
           :upload_icon,
           :default_icon_url,
+          :twitter,
+          :github,
         )
       end
 

--- a/db/migrate/20211209080221_add_twitter_and_github_to_users.rb
+++ b/db/migrate/20211209080221_add_twitter_and_github_to_users.rb
@@ -1,0 +1,6 @@
+class AddTwitterAndGithubToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :twitter, :string
+    add_column :users, :github, :string
+  end
+end

--- a/db/migrate/20211209080221_add_twitter_and_github_to_users.rb
+++ b/db/migrate/20211209080221_add_twitter_and_github_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTwitterAndGithubToUsers < ActiveRecord::Migration[6.1]
   def change
     add_column :users, :twitter, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_06_111101) do
+ActiveRecord::Schema.define(version: 2021_12_09_080221) do
 
   create_table "comments", force: :cascade do |t|
     t.string "content", null: false
@@ -52,6 +52,8 @@ ActiveRecord::Schema.define(version: 2021_12_06_111101) do
     t.string "upload_icon"
     t.string "uid", null: false
     t.string "default_icon_url", null: false
+    t.string "twitter"
+    t.string "github"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -21,10 +21,10 @@ const Login = () => {
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const [errorMessage, setErrorMessage] = useState('');
 
-  const createUser = (name, email, default_icon_url, token) => {
+  const createUser = (userParams, token) => {
     axiosAuthClient
       .post('/users', {
-        user: { name: name, email: email, default_icon_url: default_icon_url },
+        user: userParams,
         token: token,
       })
       .then((res) => {
@@ -42,7 +42,15 @@ const Login = () => {
         const email = res.user.email;
         const default_icon_url = res.user.photoURL;
         const token = res.user.Aa;
-        createUser(name, email, default_icon_url, token);
+        createUser(
+          {
+            name: name,
+            email: email,
+            default_icon_url: default_icon_url,
+            github: name,
+          },
+          token
+        );
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {
@@ -61,7 +69,14 @@ const Login = () => {
         const email = res.user.email;
         const default_icon_url = res.user.photoURL;
         const token = res.user.Aa;
-        createUser(name, email, default_icon_url, token);
+        createUser(
+          {
+            name: name,
+            email: email,
+            default_icon_url: default_icon_url,
+          },
+          token
+        );
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {
@@ -79,6 +94,7 @@ const Login = () => {
         const name = res.user.displayName;
         const email = res.user.email;
         const default_icon_url = res.user.photoURL;
+        const twitter = res.additionalUserInfo.username;
         const token = res.user.Aa;
         if (email === null) {
           auth.signOut();
@@ -87,7 +103,15 @@ const Login = () => {
           );
           return;
         }
-        createUser(name, email, default_icon_url, token);
+        createUser(
+          {
+            name: name,
+            email: email,
+            default_icon_url: default_icon_url,
+            twitter: twitter,
+          },
+          token
+        );
       })
       .catch((err) => {
         if (err.code === 'auth/account-exists-with-different-credential') {

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -27,7 +27,7 @@ const Setting = () => {
       };
       newInputValue.name = res.data.name;
       newInputValue.email = res.data.email;
-      newInputValue.twitter = res.data.twitter ? res.data.twitter: '';
+      newInputValue.twitter = res.data.twitter ? res.data.twitter : '';
       newInputValue.github = res.data.github ? res.data.github : '';
       setInputValue(newInputValue);
       setPreview(

--- a/frontend/src/pages/Setting.js
+++ b/frontend/src/pages/Setting.js
@@ -22,9 +22,13 @@ const Setting = () => {
       const newInputValue = {
         name: '',
         email: '',
+        twitter: '',
+        github: '',
       };
       newInputValue.name = res.data.name;
       newInputValue.email = res.data.email;
+      newInputValue.twitter = res.data.twitter ? res.data.twitter: '';
+      newInputValue.github = res.data.github ? res.data.github : '';
       setInputValue(newInputValue);
       setPreview(
         res.data.upload_icon.url
@@ -38,6 +42,8 @@ const Setting = () => {
     const formData = new FormData();
     formData.append('user[name]', inputValue.name);
     formData.append('user[email]', inputValue.email);
+    formData.append('user[twitter]', inputValue.twitter);
+    formData.append('user[github]', inputValue.github);
     if (icon) formData.append('user[upload_icon]', icon);
 
     axiosAuthClient
@@ -185,6 +191,20 @@ const InfoRenderer = (props) => {
         onChange={(e) => props.changeInputValue('email', e)}
         error={props.validationMessage.email !== ''}
         helperText={props.validationMessage.email}
+      />
+      <TextField
+        label='TwitterID(@以降)'
+        variant='outlined'
+        style={{ width: '40ch', marginBottom: 30 }}
+        value={props.inputValue.twitter}
+        onChange={(e) => props.changeInputValue('twitter', e)}
+      />
+      <TextField
+        label='GitHubID'
+        variant='outlined'
+        style={{ width: '40ch', marginBottom: 30 }}
+        value={props.inputValue.github}
+        onChange={(e) => props.changeInputValue('github', e)}
       />
     </Grid>
   );

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -9,6 +9,8 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import MDSpinner from 'react-md-spinner';
 import { TwitterIcon, TwitterShareButton } from 'react-share';
+import MuiTwitterIcon from '@mui/icons-material/Twitter';
+import GitHubIcon from '@mui/icons-material/GitHub';
 
 const UserDetail = (props) => {
   const { params } = props.match;
@@ -139,6 +141,30 @@ const UserDetail = (props) => {
               <span className={classes.userItem}>
                 {user.created_at.split('T')[0].substr(0, 10)}に登録
               </span>
+              <div style={{ display: 'flex' }}>
+                {user.twitter && (
+                  <span style={{ marginRight: 10 }}>
+                    <a
+                      href={`https://twitter.com/${user.twitter}`}
+                      style={{ color: 'inherit' }}
+                    >
+                      <MuiTwitterIcon
+                        style={{ color: '#4099FF', height: 30, width: 30 }}
+                      />
+                    </a>
+                  </span>
+                )}
+                {user.github && (
+                  <span>
+                    <a
+                      href={`https://github.com/${user.github}`}
+                      style={{ color: 'inherit' }}
+                    >
+                      <GitHubIcon style={{ height: 30, width: 30 }} />
+                    </a>
+                  </span>
+                )}
+              </div>
             </div>
           </Grid>
         </Grid>


### PR DESCRIPTION
### 関連issue
#164 

### やったこと
- usersテーブルにtwitterカラムとgithubカラムを追加
- 新規登録時にTwitterログインの場合は、Twitterの@からはじまるIDを、GitHubログインの場合はGitHubIDも合わせて、APIに送信し、データベースに保存
- ユーザー詳細画面でTwitter、GitHubのアイコンを押すと、そのユーザーのアカウントに飛ぶ
- ユーザー設定画面からTwitterID、GitHubIDを設定できるようにした

### UI
ユーザー詳細画面
<img width="400" alt="スクリーンショット 2021-12-10 0 15 29" src="https://user-images.githubusercontent.com/61813626/145423369-b1824c2e-c8f8-49cd-b545-04c45a60ea20.png">
ユーザー設定画面
<img width="400" alt="スクリーンショット 2021-12-10 0 16 03" src="https://user-images.githubusercontent.com/61813626/145423588-2176e510-e174-453c-9b21-8352011ffef6.png">

### 参考
- [HTMLのaタグのデフォルト状態を色々無効化する](http://urusulambda.com/2019/01/07/html%E3%81%AEa%E3%82%BF%E3%82%B0%E3%81%AE%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E7%8A%B6%E6%85%8B%E3%82%92%E8%89%B2%E3%80%85%E7%84%A1%E5%8A%B9%E5%8C%96%E3%81%99%E3%82%8B/)
