### PR TITLE
ユーザー詳細画面にユーザー設定画面へのリンクを追加する

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,9 +22,8 @@ const WaitInitialize = ({ children }) => {
   const userId = useContext(AuthContext).userId;
   const isLoading =
     loggedIn === null ||
-    userName === null ||
-    userIconUrl === null ||
-    userId === null;
+    (loggedIn === true &&
+      (userName === null || userIconUrl === null || userId === null));
   if (isLoading) {
     return (
       <div style={{ marginTop: 100, textAlign: 'center' }}>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,8 +16,16 @@ import Footer from './components/Footer';
 import MDSpinner from 'react-md-spinner';
 
 const WaitInitialize = ({ children }) => {
-  const initialized = useContext(AuthContext);
-  if (initialized.loggedIn === null) {
+  const loggedIn = useContext(AuthContext).loggedIn;
+  const userName = useContext(AuthContext).userName;
+  const userIconUrl = useContext(AuthContext).userIconUrl;
+  const userId = useContext(AuthContext).userId;
+  const isLoading =
+    loggedIn === null ||
+    userName === null ||
+    userIconUrl === null ||
+    userId === null;
+  if (isLoading) {
     return (
       <div style={{ marginTop: 100, textAlign: 'center' }}>
         <MDSpinner size={70} />

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -13,6 +13,7 @@ const Header = () => {
   const loggedIn = useContext(AuthContext).loggedIn;
   const setLoggedIn = useContext(AuthContext).setLoggedIn;
   const userName = useContext(AuthContext).userName;
+  const userId = useContext(AuthContext).userId;
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const history = useHistory();
 
@@ -65,7 +66,7 @@ const Header = () => {
             </Link>
           </li>
           <li style={listItemStyle}>
-            <Link href='/setting' style={linkStyle}>
+            <Link href={`/users/${userId}`} style={linkStyle}>
               <PersonIcon style={{ verticalAlign: 'middle' }} />
               <span style={{ verticalAlign: 'middle' }}>{userName}</span>
             </Link>

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -8,6 +8,7 @@ export const AuthContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(null);
   const [userName, setUserName] = useState(null);
   const [userIconUrl, setUserIconUrl] = useState(null);
+  const [userId, setUserId] = useState(null);
 
   useEffect(async () => {
     const uid = await new Promise((resolve) =>
@@ -22,6 +23,7 @@ export const AuthContextProvider = ({ children }) => {
             ? res.data.upload_icon.url
             : res.data.default_icon_url
         );
+        setUserId(res.data.id);
       });
     } else {
       setLoggedIn(false);
@@ -30,7 +32,14 @@ export const AuthContextProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider
-      value={{ loggedIn, setLoggedIn, userName, setUserName, userIconUrl }}
+      value={{
+        loggedIn,
+        setLoggedIn,
+        userName,
+        setUserName,
+        userIconUrl,
+        userId,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/pages/UserDetail.js
+++ b/frontend/src/pages/UserDetail.js
@@ -1,16 +1,19 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 import { axiosClient, axiosAuthClient } from '../api/axiosClient';
 import CreatedAt from '../components/CreatedAt';
 import Like from '../components/Like';
 import Grid from '@material-ui/core/Grid';
-import Link from '@material-ui/core/Link';
+import MuiLink from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import MDSpinner from 'react-md-spinner';
 import { TwitterIcon, TwitterShareButton } from 'react-share';
 import MuiTwitterIcon from '@mui/icons-material/Twitter';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import SettingsIcon from '@mui/icons-material/Settings';
 
 const UserDetail = (props) => {
   const { params } = props.match;
@@ -19,6 +22,7 @@ const UserDetail = (props) => {
   const [posts, setPosts] = useState(null);
   const [likeFlags, setLikeFlags] = useState(null);
   const loggedIn = useContext(AuthContext).loggedIn;
+  const userId = useContext(AuthContext).userId;
 
   useEffect(async () => {
     axiosClient.get(`/users/${id}`).then((res) => {
@@ -165,6 +169,18 @@ const UserDetail = (props) => {
                   </span>
                 )}
               </div>
+              {id === userId && (
+                <Button
+                  to='/setting'
+                  component={Link}
+                  variant='contained'
+                  color='primary'
+                  style={{ marginTop: 20 }}
+                >
+                  <SettingsIcon />
+                  設定画面へ
+                </Button>
+              )}
             </div>
           </Grid>
         </Grid>
@@ -192,12 +208,12 @@ const UserDetail = (props) => {
                         <Grid item xs={1} />
                         <Grid item xs={10} className={classes.post}>
                           <div className={classes.appNameAndLike}>
-                            <Link
+                            <MuiLink
                               className={classes.appName}
                               href={`/posts/${post.id}`}
                             >
                               {post.app_name}
-                            </Link>
+                            </MuiLink>
                             <div className={classes.like}>
                               <Like
                                 likeNum={post.like_num}


### PR DESCRIPTION
### 関連issue
#168 

### やったこと
- コンテキストにuserIdを保存
- ヘッダーの名前部分をユーザー詳細ページへのリンクに変更
- ログイン中のユーザーのユーザー詳細ページである場合に、設定画面へのリンクを表示

### UI
<img width="1091" alt="スクリーンショット 2021-12-12 23 51 57" src="https://user-images.githubusercontent.com/61813626/145717227-05f98648-a810-4ab4-ab83-808eb7f41868.png">

### 備考
AuthContext.jsのここの部分
```js
const [userName, setUserName] = useState(null);
const [userIconUrl, setUserIconUrl] = useState(null);
const [userId, setUserId] = useState(null);
```
普通に`const [user, setUser] = useState(null);`で良くない?と思った
別のPRで修正する