### PR TITLE
ブラウザバックした時のいいね表示が遅れる問題の修正

### DIFF
--- a/frontend/src/pages/PostList.js
+++ b/frontend/src/pages/PostList.js
@@ -18,6 +18,9 @@ const App = () => {
   const [totalPages, setTotalPages] = useState(null);
 
   useEffect(async () => {
+    setPostAndUsers(null);
+    setLikeFlags(null);
+
     const posts_and_users = await new Promise((resolve) => {
       axiosClient.get(`/posts?page=${page}&per=10`).then((res) => {
         setPostAndUsers(res.data.posts_and_users);
@@ -107,9 +110,6 @@ const Pagination = (props) => {
         count={props.totalPages}
         color='primary'
         onChange={(_, page) => {
-          if (props.page === page) return;
-          props.setPostAndUsers(null);
-          props.setLikeFlags(null);
           history.push(`/posts?page=${page}`);
         }}
         page={props.page}


### PR DESCRIPTION
### 関連issue
#161 

### やったこと
#162 の修正はページ番号をクリックしたときのいいね表示が遅れる問題は解決してるが、ブラウザバックした時は、前と変わらず、いいね表示が遅れてしまう。単純に`useEffect`の先頭でstateをnullにすればいいだけだった。