### PR TITLE
GET /users/searchいらない

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -44,15 +44,6 @@ module Api
         end
       end
 
-      def search
-        user = User.find_by(uid: params[:uid])
-        if user
-          render status: :ok, json: user
-        else
-          render status: :not_found
-        end
-      end
-
       def posts
         user = User.find(params[:id])
         if user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :users, only: %i[show create] do
         collection do
-          get :search
           get '/me', to: 'users#show_me'
           patch '/me', to: 'users#update_me'
         end

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -8,18 +8,15 @@ export const AuthContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(null);
   const [user, setUser] = useState(null);
 
-  useEffect(async () => {
-    const uid = await new Promise((resolve) =>
-      auth.onAuthStateChanged((user) => resolve(user?.uid))
-    );
-    if (uid) {
-      setLoggedIn(true);
-      axiosAuthClient.get(`/users/search?uid=${uid}`).then((res) => {
-        setUser(res.data);
-      });
-    } else {
-      setLoggedIn(false);
-    }
+  useEffect(() => {
+    auth.onAuthStateChanged((user) => {
+      if (user) {
+        setLoggedIn(true);
+        axiosAuthClient.get(`/users/me`).then((res) => setUser(res.data));
+      } else {
+        setLoggedIn(false);
+      }
+    });
   }, []);
 
   return (


### PR DESCRIPTION
### 関連issue
#114

### やったこと
#134 で作ったGET /users/search?uid=... は普通にGET /users/meで良い なんで実装したんだろう...
- GET /users/searchの削除
- コンテキストでリロード時にGET /users/meを叩くように修正