### PR TITLE
投稿の編集と削除をできるようにした

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import PostDetail from './pages/PostDetail';
 import Setting from './pages/Setting';
 import UserDetail from './pages/UserDetail';
 import PostForm from './pages/PostForm';
+import PostEdit from './pages/PostEdit';
 import NotFound from './pages/NotFound';
 import Footer from './components/Footer';
 import MDSpinner from 'react-md-spinner';
@@ -70,6 +71,7 @@ const App = () => {
                   <PrivateRoute path='/setting' component={Setting} />
                   <Route path='/users/:id' component={UserDetail} />
                   <PrivateRoute path='/posts/new' component={PostForm} />
+                  <PrivateRoute path='/posts/:id/edit' component={PostEdit} />
                   <Route path='/posts/:id' component={PostDetail} />
                   <Route component={NotFound} />
                 </Switch>

--- a/frontend/src/components/DeleteConfirm.js
+++ b/frontend/src/components/DeleteConfirm.js
@@ -14,7 +14,7 @@ const DeleteModal = (props) => {
       <DialogTitle id='alert-dialog-title'>{props.title}</DialogTitle>
       <DialogActions>
         <Button onClick={props.handleClose}>キャンセル</Button>
-        <Button color='secondary' onClick={props.handleClose}>
+        <Button color='secondary' onClick={props.deletePost}>
           削除する
         </Button>
       </DialogActions>

--- a/frontend/src/components/DeleteConfirm.js
+++ b/frontend/src/components/DeleteConfirm.js
@@ -1,0 +1,25 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogTitle from '@mui/material/DialogTitle';
+
+const DeleteModal = (props) => {
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.handleClose}
+      aria-labelledby='alert-dialog-title'
+      aria-describedby='alert-dialog-description'
+    >
+      <DialogTitle id='alert-dialog-title'>{props.title}</DialogTitle>
+      <DialogActions>
+        <Button onClick={props.handleClose}>キャンセル</Button>
+        <Button color='secondary' onClick={props.handleClose}>
+          削除する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteModal;

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -13,6 +13,7 @@ import CreatedAt from '../components/CreatedAt';
 import CommentList from '../components/CommentList';
 import Like from '../components/Like';
 import Tags from '../components/Tags';
+import DeleteConfirm from '../components/DeleteConfirm';
 import MDSpinner from 'react-md-spinner';
 
 const PostDetail = (props) => {
@@ -28,6 +29,7 @@ const PostDetail = (props) => {
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const [likeNum, setLikeNum] = useState(null);
   const [likeFlag, setLikeFlag] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
     const callback = (res) => {
@@ -203,7 +205,13 @@ const PostDetail = (props) => {
             <Grid item xs={2} lg={1} />
             <Grid item xs={10} lg={11}>
               <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <Link href={`/posts/${id}/edit`}>編集する</Link>
+                <Link href={`/posts/${id}/edit`} style={{marginRight: 10, textDecoration: 'none'}}>編集する</Link>
+                <span onClick={() => setModalOpen(true)} style={{color: 'red'}}>削除する</span>
+                <DeleteConfirm
+                  open={modalOpen}
+                  handleClose={() => setModalOpen(false)}
+                  title={`${post.app_name}を削除して良いですか？`}
+                />
               </div>
             </Grid>
           </Grid>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -5,6 +5,7 @@ import { axiosAuthClient, axiosClient } from '../api/axiosClient';
 import marked from 'marked';
 import DOMPurify from 'dompurify';
 import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
 import { makeStyles } from '@mui/styles';
 import Owner from '../components/Owner';
 import CommentForm from '../components/CommentForm';
@@ -197,6 +198,16 @@ const PostDetail = (props) => {
             </div>
           </Grid>
         </Grid>
+        {ownerId === user.id && (
+          <Grid container>
+            <Grid item xs={2} lg={1} />
+            <Grid item xs={10} lg={11}>
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Link href={`/posts/${id}/edit`}>編集する</Link>
+              </div>
+            </Grid>
+          </Grid>
+        )}
         <div style={{ marginTop: 50 }}>
           <CommentForm submitComment={submitComment} />
         </div>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -73,12 +73,11 @@ const PostDetail = (props) => {
   };
 
   const deletePost = () => {
-    axiosAuthClient.delete(`/posts/${id}`)
-      .then(() => {
-        history.push('/posts');
-        updateFlashMessage({ successMessage: '削除しました' });
-      });
-    };
+    axiosAuthClient.delete(`/posts/${id}`).then(() => {
+      history.push('/posts');
+      updateFlashMessage({ successMessage: '削除しました' });
+    });
+  };
 
   const createLike = () => {
     if (!loggedIn) return;
@@ -215,8 +214,18 @@ const PostDetail = (props) => {
             <Grid item xs={2} lg={1} />
             <Grid item xs={10} lg={11}>
               <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <Link href={`/posts/${id}/edit`} style={{marginRight: 10, textDecoration: 'none'}}>編集する</Link>
-                <span onClick={() => setModalOpen(true)} style={{color: 'red'}}>削除する</span>
+                <Link
+                  href={`/posts/${id}/edit`}
+                  style={{ marginRight: 10, textDecoration: 'none' }}
+                >
+                  編集する
+                </Link>
+                <span
+                  onClick={() => setModalOpen(true)}
+                  style={{ color: 'red' }}
+                >
+                  削除する
+                </span>
                 <DeleteConfirm
                   deletePost={deletePost}
                   open={modalOpen}

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -222,7 +222,7 @@ const PostDetail = (props) => {
                 </Link>
                 <span
                   onClick={() => setModalOpen(true)}
-                  style={{ color: 'red' }}
+                  style={{ color: 'red', cursor: 'pointer' }}
                 >
                   削除する
                 </span>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 import { FlashMessageContext } from '../contexts/FlashMessageContext';
 import { axiosAuthClient, axiosClient } from '../api/axiosClient';
@@ -30,6 +31,7 @@ const PostDetail = (props) => {
   const [likeNum, setLikeNum] = useState(null);
   const [likeFlag, setLikeFlag] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const history = useHistory();
 
   useEffect(() => {
     const callback = (res) => {
@@ -69,6 +71,14 @@ const PostDetail = (props) => {
         updateFlashMessage({ successMessage: 'コメントをつけました' });
       });
   };
+
+  const deletePost = () => {
+    axiosAuthClient.delete(`/posts/${id}`)
+      .then(() => {
+        history.push('/posts');
+        updateFlashMessage({ successMessage: '削除しました' });
+      });
+    };
 
   const createLike = () => {
     if (!loggedIn) return;
@@ -208,6 +218,7 @@ const PostDetail = (props) => {
                 <Link href={`/posts/${id}/edit`} style={{marginRight: 10, textDecoration: 'none'}}>編集する</Link>
                 <span onClick={() => setModalOpen(true)} style={{color: 'red'}}>削除する</span>
                 <DeleteConfirm
+                  deletePost={deletePost}
                   open={modalOpen}
                   handleClose={() => setModalOpen(false)}
                   title={`${post.app_name}を削除して良いですか？`}

--- a/frontend/src/pages/PostEdit.js
+++ b/frontend/src/pages/PostEdit.js
@@ -1,0 +1,185 @@
+import React, { useEffect, useState, useMemo, useContext } from 'react';
+import { FlashMessageContext } from '../contexts/FlashMessageContext';
+import { useHistory } from 'react-router-dom';
+import { axiosAuthClient, axiosClient } from '../api/axiosClient';
+import SimpleMDE from 'react-simplemde-editor';
+import 'easymde/dist/easymde.min.css';
+import Select from 'react-select';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import MDSpinner from 'react-md-spinner';
+
+const PostEdit = (props) => {
+  const style = {
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const { params } = props.match;
+  const id = parseInt(params.id, 10);
+  const [inputValue, setInputValue] = useState(null);
+  const [validationMessage, setValidationMessage] = useState({
+    app_name: '',
+    app_url: '',
+    repo_url: '',
+    description: '',
+  });
+  const [markdown, setMarkdown] = useState();
+  const markdownOption = useMemo(() => {
+    return {
+      toolbar: ['preview'],
+      spellChecker: false,
+    };
+  }, []);
+  const history = useHistory();
+  const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
+  const [tags, setTags] = useState(null);
+  const [tagIds, setTagIds] = useState([]);
+
+  useEffect(async () => {
+    await axiosClient.get(`/posts/${id}`).then((res) => {
+      const post = res.data.post;
+      setInputValue({
+        app_name: post.app_name,
+        app_url: post.app_url,
+        repo_url: post.repo_url,
+      });
+      setTagIds(post.tags.map(tag => tag.id));
+      setMarkdown(post.description);
+    });
+
+    axiosAuthClient.get('/tags').then((res) => {
+      setTags(
+        res.data.map((tag) => {
+          return { label: tag.name, value: tag.id };
+        })
+      );
+    });
+  }, []);
+
+  const changeInputValue = (itemName, e) => {
+    const newInputValue = Object.assign({}, inputValue);
+    newInputValue[itemName] = e.target.value;
+    setInputValue(newInputValue);
+  };
+
+  const updatePost = async () => {
+    const postId = await axiosAuthClient
+      .patch(`/posts/${id}`, {
+        post: Object.assign({}, inputValue, { description: markdown }),
+      })
+      .then((res) => {
+        return res.data.id;
+      })
+      .catch((err) => {
+        if (err.response.status === 400) {
+          const newValidationMessage = {
+            app_name: '',
+            app_url: '',
+            repo_url: '',
+            description: '',
+          };
+          for (const property in err.response.data) {
+            newValidationMessage[property] = err.response.data[property][0];
+          }
+          setValidationMessage(newValidationMessage);
+        }
+      });
+
+    if (!postId) return;
+
+    axiosAuthClient
+      .patch(`/posts/${postId}/taggings`, {
+        tag_ids: tagIds,
+      })
+      .then(() => {
+        history.push(`/posts/${postId}`);
+        updateFlashMessage({ successMessage: '更新しました' });
+      });
+  };
+
+  const isLoading = tags === null;
+
+  return isLoading ? (
+    <div style={{ marginTop: 100, textAlign: 'center' }}>
+      <MDSpinner size={70} />
+    </div>
+  ) : (
+    <Grid container style={{ paddingTop: 100 }}>
+      <Grid item xs={1} lg={3} />
+      <Grid item xs={10} lg={6} style={style}>
+        <p style={{ fontSize: 18, margin: 0 }}>
+          1. アプリ名を入力してください。
+        </p>
+        <TextField
+          variant='outlined'
+          style={{ marginBottom: 30 }}
+          value={inputValue.app_name}
+          onChange={(e) => changeInputValue('app_name', e)}
+          error={validationMessage.app_name !== ''}
+          helperText={validationMessage.app_name}
+        />
+        <p style={{ fontSize: 18, margin: 0 }}>
+          2. デプロイ先のURLを入力してください。
+        </p>
+        <TextField
+          variant='outlined'
+          style={{ marginBottom: 30 }}
+          value={inputValue.app_url}
+          onChange={(e) => changeInputValue('app_url', e)}
+          error={validationMessage.app_url !== ''}
+          helperText={validationMessage.app_url}
+        />
+        <p style={{ fontSize: 18, margin: 0 }}>
+          3. レポジトリのURLを入力してください。
+        </p>
+        <TextField
+          variant='outlined'
+          style={{ marginBottom: 30 }}
+          value={inputValue.repo_url}
+          onChange={(e) => changeInputValue('repo_url', e)}
+          error={validationMessage.repo_url !== ''}
+          helperText={validationMessage.repo_url}
+        />
+        <p style={{ fontSize: 18, margin: 0 }}>
+          4. 使用した技術を選択してください。(複数選択可)
+        </p>
+        <div style={{ marginBottom: 30 }}>
+          <Select
+            defaultValue={tagIds.map(tagId => tags.find(tag => tag.value === tagId))}
+            isMulti
+            options={tags}
+            onChange={(arr) => setTagIds(arr.map((e) => e.value))}
+            placeholder='使用技術'
+          />
+        </div>
+        <p style={{ fontSize: 18, margin: 0 }}>
+          5. アプリの概要や工夫点を入力してください。
+        </p>
+        <SimpleMDE
+          value={markdown}
+          onChange={(e) => setMarkdown(e)}
+          style={{ width: '100%' }}
+          options={markdownOption}
+        />
+        <p style={{ color: 'red', padding: 5 }}>
+          {validationMessage.description}
+        </p>
+        <Grid container alignItems='center' justifyContent='center'>
+          <Button
+            variant='contained'
+            color='primary'
+            style={{ marginBottom: 30, width: 300 }}
+            onClick={updatePost}
+          >
+            更新
+          </Button>
+        </Grid>
+      </Grid>
+      <Grid item xs={1} lg={3} />
+    </Grid>
+  );
+};
+
+export default PostEdit;

--- a/frontend/src/pages/PostEdit.js
+++ b/frontend/src/pages/PostEdit.js
@@ -53,7 +53,7 @@ const PostEdit = (props) => {
         app_url: post.app_url,
         repo_url: post.repo_url,
       });
-      setTagIds(post.tags.map(tag => tag.id));
+      setTagIds(post.tags.map((tag) => tag.id));
       setMarkdown(post.description);
     });
 
@@ -155,7 +155,9 @@ const PostEdit = (props) => {
         </p>
         <div style={{ marginBottom: 30 }}>
           <Select
-            defaultValue={tagIds.map(tagId => tags.find(tag => tag.value === tagId))}
+            defaultValue={tagIds.map((tagId) =>
+              tags.find((tag) => tag.value === tagId)
+            )}
             isMulti
             options={tags}
             onChange={(arr) => setTagIds(arr.map((e) => e.value))}

--- a/frontend/src/pages/PostEdit.js
+++ b/frontend/src/pages/PostEdit.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo, useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 import { FlashMessageContext } from '../contexts/FlashMessageContext';
 import { useHistory } from 'react-router-dom';
 import { axiosAuthClient, axiosClient } from '../api/axiosClient';
@@ -33,12 +34,19 @@ const PostEdit = (props) => {
     };
   }, []);
   const history = useHistory();
+  const loginUser = useContext(AuthContext).user;
   const updateFlashMessage = useContext(FlashMessageContext).updateFlashMessage;
   const [tags, setTags] = useState(null);
   const [tagIds, setTagIds] = useState([]);
 
   useEffect(async () => {
     await axiosClient.get(`/posts/${id}`).then((res) => {
+      const ownerId = res.data.user.id;
+      if (ownerId !== loginUser.id) {
+        history.push('/posts');
+        updateFlashMessage({ errorMessage: '権限がありません' });
+      }
+
       const post = res.data.post;
       setInputValue({
         app_name: post.app_name,


### PR DESCRIPTION
### 関連issue
#112

### やったこと
- 投稿更新ページの作成
  ほとんど投稿作成ページと一緒
  ログイン中のユーザーの投稿である場合は、投稿詳細ページに投稿更新ページへのリンクを表示する
  URLによる不正なアクセスの場合は、/postsに戻す
- 投稿の削除をできるようにした
  ログイン中のユーザーの投稿である場合は、投稿詳細ページに削除すると表示する
  これを押すと、モーダルが表示され、削除するを選ぶと削除されて、/postsに飛ぶ
  
### UI
編集と削除

https://user-images.githubusercontent.com/61813626/146683717-1adc5e70-5157-49be-aa0d-ed2047086040.mov

アクセス制御

https://user-images.githubusercontent.com/61813626/146683820-531a7d7e-10b0-459c-a14d-211c59c44c6d.mov

### 参考
- [[Javascript] 配列から特定の要素を取り出す(splice, findIndex, pop, shift)](https://webbibouroku.com/Blog/Article/js-array-1)
- [Dialog](https://mui.com/components/dialogs/)
- [CSSで、マウスカーソルを指マークに変更する方法](https://www-creators.com/archives/2504)