### PR TITLE
残っていたN+1の除去 + includesを使うのをやめる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
+  gem 'bullet'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
     bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (7.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     carrierwave (2.2.2)
       activemodel (>= 5.0.0)
@@ -470,6 +473,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    uniform_notifier (1.14.2)
     webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -486,6 +490,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   carrierwave
   dotenv-rails

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -14,7 +14,7 @@ module Api
                 end
 
         posts = posts.page(params[:page]).per(params[:per])
-        posts = posts.includes(:user, :tags)
+        posts = posts.eager_load(:user).preload(:tags)
         pagination = pagination(posts)
         posts_and_users = []
 
@@ -34,7 +34,7 @@ module Api
       end
 
       def recent
-        posts = Post.all.includes(:user).order(id: 'DESC').limit(4)
+        posts = Post.all.eager_load(:user).preload(:tags).order(id: 'DESC').limit(4)
         posts_and_users = []
         posts.each do |post|
           posts_and_users.push({ post: post.as_json.merge({ tags: post.tags }), user: post.user })
@@ -45,7 +45,7 @@ module Api
       def show
         post = Post.find(params[:id])
         comments_and_users = []
-        post.comments.includes(:user).each do |comment|
+        post.comments.eager_load(:user).each do |comment|
           user = comment.user
           user_icon_url = user.upload_icon.url || user.default_icon_url
           comments_and_users.push({ comment: comment, user_id: user.id, user_name: user.name, user_icon_url: user_icon_url })

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -47,12 +47,13 @@ module Api
       def posts
         user = User.find(params[:id])
         if user
+          posts = user.posts.preload(:tags)
           if request.headers['Authorization']
-            render status: :ok, json: user.posts.map { |post|
+            render status: :ok, json: posts.map { |post|
               post.as_json.merge({ like_flag: Like.exists?(post_id: post.id, user_id: current_user.id), tags: post.tags })
             }
           else
-            render status: :ok, json: user.posts.map { |post| post.as_json.merge({ tags: post.tags }) }
+            render status: :ok, json: posts.map { |post| post.as_json.merge({ tags: post.tags }) }
           end
         else
           render status: :not_found

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,16 @@
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
     Bullet.alert         = true
     Bullet.bullet_logger = true
     Bullet.console       = true
-  # Bullet.growl         = true
+    # Bullet.growl         = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
   end


### PR DESCRIPTION
### 関連issue
#195 

### やったこと
- bulletのインストール
- 残っていたN+1の解消とincludesを使うのをやめた
N+1となる部分は、postsテーブルからusersテーブルとtagsテーブルへのアソシエーションと、commentsテーブルからusersテーブルへのアソシエーション
postsテーブルからusersテーブルはbelongs_toなので、eager_loadを選択
postsテーブルからtagsテーブルはhas_manyかつtaggingsテーブルを跨ぐので、preloadを選択
commentsテーブルからusersテーブルはbelongs_toなので、eager_loadを選択
例えば、PostsControllerのindexの処理は以下のように変わった
修正前
```
 ↳ app/controllers/concerns/pagination.rb:8:in `pagination'
  Post Load (0.3ms)  SELECT "posts".* FROM "posts" ORDER BY "posts"."id" DESC LIMIT ? OFFSET ?  [["LIMIT", 10], ["OFFSET", 0]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
  User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?)  [["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
  Tagging Load (0.5ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."post_id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  [["post_id", 10], ["post_id", 9], ["post_id", 8], ["post_id", 7], ["post_id", 6], ["post_id", 5], ["post_id", 4], ["post_id", 3], ["post_id", 2], ["post_id", 1]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
  Tag Load (0.6ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  [["id", 13], ["id", 3], ["id", 21], ["id", 12], ["id", 19], ["id", 11], ["id", 14], ["id", 24], ["id", 10], ["id", 1], ["id", 7], ["id", 15], ["id", 6], ["id", 5], ["id", 22], ["id", 9], ["id", 20], ["id", 23], ["id", 17], ["id", 18]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
Completed 200 OK in 45ms (Views: 13.8ms | ActiveRecord: 2.0ms | Allocations: 35845)
```
修正後
```
 ↳ app/controllers/concerns/pagination.rb:8:in `pagination'
  SQL (0.3ms)  SELECT "posts"."id" AS t0_r0, "posts"."created_at" AS t0_r1, "posts"."updated_at" AS t0_r2, "posts"."user_id" AS t0_r3, "posts"."app_name" AS t0_r4, "posts"."app_url" AS t0_r5, "posts"."repo_url" AS t0_r6, "posts"."description" AS t0_r7, "posts"."like_num" AS t0_r8, "users"."id" AS t1_r0, "users"."name" AS t1_r1, "users"."email" AS t1_r2, "users"."created_at" AS t1_r3, "users"."updated_at" AS t1_r4, "users"."upload_icon" AS t1_r5, "users"."uid" AS t1_r6, "users"."default_icon_url" AS t1_r7, "users"."twitter" AS t1_r8, "users"."github" AS t1_r9 FROM "posts" LEFT OUTER JOIN "users" ON "users"."id" = "posts"."user_id" ORDER BY "posts"."id" DESC LIMIT ? OFFSET ?  [["LIMIT", 10], ["OFFSET", 0]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
  Tagging Load (0.6ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."post_id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  [["post_id", 10], ["post_id", 9], ["post_id", 8], ["post_id", 7], ["post_id", 6], ["post_id", 5], ["post_id", 4], ["post_id", 3], ["post_id", 2], ["post_id", 1]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
  Tag Load (0.5ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  [["id", 13], ["id", 3], ["id", 21], ["id", 12], ["id", 19], ["id", 11], ["id", 14], ["id", 24], ["id", 10], ["id", 1], ["id", 7], ["id", 15], ["id", 6], ["id", 5], ["id", 22], ["id", 9], ["id", 20], ["id", 23], ["id", 17], ["id", 18]]
  ↳ app/controllers/api/v1/posts_controller.rb:28:in `index'
Completed 200 OK in 74ms (Views: 13.2ms | ActiveRecord: 4.4ms | Allocations: 49745)
```
クエリの発行回数が1回減っている
修正後に一通りのUI操作を行い、bulletの警告が出ないことを確認した

### 備考
ブラウザにポップアップを出せるらしいのだが、出来なかった
ログやlog/bullet.logを見て修正した

### 参考
- [【Rails】N+1問題 （Bullet で検出し includes して対策）](https://qiita.com/maru_maruo/items/3b16bf37aa153992cefd)
- [【Rails】N+1問題をアラート表示してくれるgem「bullet」が超絶便利だった！](https://techtechmedia.com/nplusone_query-bullet-rails/)
- [Railsライブラリ紹介: N+1問題を検出する「bullet」](https://www.techscore.com/blog/2012/12/25/rails%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E7%B4%B9%E4%BB%8B-n1%E5%95%8F%E9%A1%8C%E3%82%92%E6%A4%9C%E5%87%BA%E3%81%99%E3%82%8B%E3%80%8Cbullet%E3%80%8D/)
