### PR TITLE
GET /posts/recentをクエリパラメータを受け取れるようにした

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -34,7 +34,7 @@ module Api
       end
 
       def recent
-        posts = Post.all.eager_load(:user).preload(:tags).order(id: 'DESC').limit(4)
+        posts = Post.all.eager_load(:user).preload(:tags).order(id: 'DESC').limit(params[:limit])
         posts_and_users = []
         posts.each do |post|
           posts_and_users.push({ post: post.as_json.merge({ tags: post.tags }), user: post.user })

--- a/frontend/src/pages/Top.js
+++ b/frontend/src/pages/Top.js
@@ -13,7 +13,7 @@ const Top = () => {
   const [postsAndUsers, setPostsAndUsers] = useState(null);
 
   useEffect(() => {
-    axiosClient.get('/posts/recent').then((res) => setPostsAndUsers(res.data));
+    axiosClient.get('/posts/recent?limit=4').then((res) => setPostsAndUsers(res.data));
   }, []);
 
   const styles = makeStyles({

--- a/frontend/src/pages/Top.js
+++ b/frontend/src/pages/Top.js
@@ -13,7 +13,9 @@ const Top = () => {
   const [postsAndUsers, setPostsAndUsers] = useState(null);
 
   useEffect(() => {
-    axiosClient.get('/posts/recent?limit=4').then((res) => setPostsAndUsers(res.data));
+    axiosClient
+      .get('/posts/recent?limit=4')
+      .then((res) => setPostsAndUsers(res.data));
   }, []);
 
   const styles = makeStyles({


### PR DESCRIPTION
### 関連issue
#198 

### やったこと
GET /posts/recentで取得する投稿の件数をクエリパラメータlimitで指定するように変更した

### 備考
limitで指定された値がレコード数より大きくてもエラーにならない(全ての投稿が返る)