### PR TITLE
他の人の投稿を編集、削除できないようにした

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class PostsController < ApplicationController
       skip_before_action :authenticate_user, only: %i[index recent show]
+      before_action :ensure_correct_user, only: %i[update destroy]
       include Pagination
 
       def index
@@ -91,6 +92,10 @@ module Api
 
       def post_params
         params.require(:post).permit(:app_name, :app_url, :repo_url, :description)
+      end
+
+      def ensure_correct_user
+        render status: :forbidden unless current_user.posts.find_by(id: params[:id])
       end
     end
   end


### PR DESCRIPTION
### 関連issue
#203 

### やったこと
- PostsControllerのupdateメソッドとdeleteメソッドの実行前に、ensure_correct_userメソッドを実行するようにした
  ensure_correct_userメソッドでは、ログイン中のユーザーの投稿にパスパラメータで指定されるidの投稿があるかどうかを判定し、ない場合は403を返す

### 備考
- ログイン中のユーザーのidと投稿のユーザーidを比較しても良いんだけど、このPRの方針の方が速そうな気がする(indexの仕組みを理解できていないので分からない)
- before_actionの実行順番が気になったが、あまり資料が出てこなかった

### 参考
- [【Rails】findとfind_byと404エラーとnilと劇的な見せ方をされた知識って忘れそうにない、という話](https://kentarotawara.hatenablog.com/entry/2021/01/08/004310)
- [継承元のApplicationControllerに定義したbefore_actionと各コントローラーに定義したbefore_actionの実行順](https://remoter.hatenablog.com/entry/2020/02/07/%E7%B6%99%E6%89%BF%E5%85%83%E3%81%AEApplicationController%E3%81%AB%E5%AE%9A%E7%BE%A9%E3%81%97%E3%81%9Fbefore_action%E3%81%A8%E5%90%84%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC)
