### PR TITLE
コメントの編集と削除

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -3,13 +3,22 @@
 module Api
   module V1
     class CommentsController < ApplicationController
-      before_action :ensure_correct_user, only: %i[destroy]
+      before_action :ensure_correct_user, only: %i[update, destroy]
 
       def create
         comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))
         if comment.save
           CommentMailer.comment_notification(comment).deliver_now if current_user.id != comment.post.user.id
           render status: :created, json: comment
+        else
+          render status: :bad_request, json: comment.errors
+        end
+      end
+
+      def update
+        comment = Comment.find(params[:id])
+        if comment.update(comment_params)
+          render status: :ok, json: comment
         else
           render status: :bad_request, json: comment.errors
         end

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class CommentsController < ApplicationController
-      before_action :ensure_correct_user, only: %i[update, destroy]
+      before_action :ensure_correct_user, only: %i[update destroy]
 
       def create
         comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class CommentsController < ApplicationController
+      before_action :ensure_correct_user, only: %i[destroy]
+
       def create
         comment = current_user.comments.build(comment_params.merge({ post_id: params[:post_id] }))
         if comment.save
@@ -13,10 +15,20 @@ module Api
         end
       end
 
+      def destroy
+        comment = Comment.find(params[:id])
+        comment.destroy
+        render status: :no_content
+      end
+
       private
 
       def comment_params
         params.require(:comment).permit(:content)
+      end
+
+      def ensure_correct_user
+        render status: :forbidden unless current_user.comments.find_by(id: params[:id])
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
         collection do
           get :recent
         end
-        resources :comments, only: %i[create destroy]
+        resources :comments, only: %i[create update destroy]
         resources :likes, only: [:create] do
           collection do
             delete '', to: 'likes#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
         collection do
           get :recent
         end
-        resources :comments, only: [:create]
+        resources :comments, only: %i[create destroy]
         resources :likes, only: [:create] do
           collection do
             delete '', to: 'likes#destroy'

--- a/frontend/src/components/Comment.js
+++ b/frontend/src/components/Comment.js
@@ -1,7 +1,8 @@
-import React, { useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
 import Owner from './Owner';
 import CreatedAt from './CreatedAt';
+import DeleteConfirm from './DeleteConfirm';
 import marked from 'marked';
 import DOMPurify from 'dompurify';
 import { makeStyles } from '@mui/styles';
@@ -9,6 +10,7 @@ import Grid from '@mui/material/Grid';
 
 const Comment = (props) => {
   const loginUser = useContext(AuthContext).user;
+  const [modalOpen, setModalOpen] = useState(false);
 
   const styles = makeStyles({
     comment: {
@@ -57,7 +59,21 @@ const Comment = (props) => {
         {props.commentAndUser.user.id === loginUser.id && (
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
             <span style={{ marginRight: 10 }}>編集する</span>
-            <span>削除する</span>
+            <span
+              onClick={() => setModalOpen(true)}
+              style={{ color: 'red', cursor: 'pointer' }}
+            >
+              削除する
+            </span>
+            <DeleteConfirm
+              deletePost={() => {
+                props.deleteComment();
+                setModalOpen(false);
+              }}
+              open={modalOpen}
+              handleClose={() => setModalOpen(false)}
+              title={'このコメントを削除して良いですか？'}
+            />
           </div>
         )}
       </Grid>

--- a/frontend/src/components/Comment.js
+++ b/frontend/src/components/Comment.js
@@ -3,6 +3,7 @@ import { AuthContext } from '../contexts/AuthContext';
 import Owner from './Owner';
 import CreatedAt from './CreatedAt';
 import DeleteConfirm from './DeleteConfirm';
+import CommentEdit from './CommentEdit';
 import marked from 'marked';
 import DOMPurify from 'dompurify';
 import { makeStyles } from '@mui/styles';
@@ -10,6 +11,7 @@ import Grid from '@mui/material/Grid';
 
 const Comment = (props) => {
   const loginUser = useContext(AuthContext).user;
+  const [editOpen, setEditOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
 
   const styles = makeStyles({
@@ -32,52 +34,74 @@ const Comment = (props) => {
   const classes = styles();
 
   return (
-    <Grid container className={classes.comment}>
-      <Grid item xs={2} lg={1}>
-        <div style={{ marginTop: 10 }}>
-          <Owner
-            userId={props.commentAndUser.user.id}
-            userName={props.commentAndUser.user.name}
-            userIconUrl={props.commentAndUser.user.icon_url}
+    <div>
+      {editOpen ? (
+        <div style={{ marginBottom: 30 }}>
+          <CommentEdit
+            editComment={props.editComment}
+            handleClose={() => setEditOpen(false)}
           />
         </div>
-      </Grid>
-      <Grid item xs={10} lg={11}>
-        <div className={classes.commentRight}>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(
-                marked(props.commentAndUser.comment.content)
-              ),
-            }}
-            style={{ borderBottom: 'solid 1px #bbb' }}
-          ></div>
-          <div className={classes.commentRightFooter}>
-            <CreatedAt createdAt={props.commentAndUser.comment.created_at} />
-          </div>
-        </div>
-        {props.commentAndUser.user.id === loginUser.id && (
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <span style={{ marginRight: 10 }}>編集する</span>
-            <span
-              onClick={() => setModalOpen(true)}
-              style={{ color: 'red', cursor: 'pointer' }}
-            >
-              削除する
-            </span>
-            <DeleteConfirm
-              deletePost={() => {
-                props.deleteComment();
-                setModalOpen(false);
-              }}
-              open={modalOpen}
-              handleClose={() => setModalOpen(false)}
-              title={'このコメントを削除して良いですか？'}
-            />
-          </div>
-        )}
-      </Grid>
-    </Grid>
+      ) : (
+        <Grid container className={classes.comment}>
+          <Grid item xs={2} lg={1}>
+            <div style={{ marginTop: 10 }}>
+              <Owner
+                userId={props.commentAndUser.user.id}
+                userName={props.commentAndUser.user.name}
+                userIconUrl={props.commentAndUser.user.icon_url}
+              />
+            </div>
+          </Grid>
+          <Grid item xs={10} lg={11}>
+            <div className={classes.commentRight}>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(
+                    marked(props.commentAndUser.comment.content)
+                  ),
+                }}
+                style={{ borderBottom: 'solid 1px #bbb' }}
+              ></div>
+              <div className={classes.commentRightFooter}>
+                <CreatedAt
+                  createdAt={props.commentAndUser.comment.created_at}
+                />
+              </div>
+            </div>
+            {props.commentAndUser.user.id === loginUser?.id && (
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <span
+                  onClick={() => setEditOpen(true)}
+                  style={{
+                    color: '#1976D2',
+                    cursor: 'pointer',
+                    marginRight: 10,
+                  }}
+                >
+                  編集する
+                </span>
+                <span
+                  onClick={() => setModalOpen(true)}
+                  style={{ color: 'red', cursor: 'pointer' }}
+                >
+                  削除する
+                </span>
+                <DeleteConfirm
+                  deletePost={() => {
+                    props.deleteComment();
+                    setModalOpen(false);
+                  }}
+                  open={modalOpen}
+                  handleClose={() => setModalOpen(false)}
+                  title={'このコメントを削除して良いですか？'}
+                />
+              </div>
+            )}
+          </Grid>
+        </Grid>
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/Comment.js
+++ b/frontend/src/components/Comment.js
@@ -1,3 +1,5 @@
+import React, { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 import Owner from './Owner';
 import CreatedAt from './CreatedAt';
 import marked from 'marked';
@@ -6,6 +8,8 @@ import { makeStyles } from '@mui/styles';
 import Grid from '@mui/material/Grid';
 
 const Comment = (props) => {
+  const loginUser = useContext(AuthContext).user;
+
   const styles = makeStyles({
     comment: {
       marginBottom: 30,
@@ -36,18 +40,26 @@ const Comment = (props) => {
           />
         </div>
       </Grid>
-      <Grid item xs={10} lg={11} className={classes.commentRight}>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(
-              marked(props.commentAndUser.comment.content)
-            ),
-          }}
-          style={{ borderBottom: 'solid 1px #bbb' }}
-        ></div>
-        <div className={classes.commentRightFooter}>
-          <CreatedAt createdAt={props.commentAndUser.comment.created_at} />
+      <Grid item xs={10} lg={11}>
+        <div className={classes.commentRight}>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(
+                marked(props.commentAndUser.comment.content)
+              ),
+            }}
+            style={{ borderBottom: 'solid 1px #bbb' }}
+          ></div>
+          <div className={classes.commentRightFooter}>
+            <CreatedAt createdAt={props.commentAndUser.comment.created_at} />
+          </div>
         </div>
+        {props.commentAndUser.user.id === loginUser.id && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <span style={{ marginRight: 10 }}>編集する</span>
+            <span>削除する</span>
+          </div>
+        )}
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/Comment.js
+++ b/frontend/src/components/Comment.js
@@ -1,0 +1,56 @@
+import Owner from './Owner';
+import CreatedAt from './CreatedAt';
+import marked from 'marked';
+import DOMPurify from 'dompurify';
+import { makeStyles } from '@mui/styles';
+import Grid from '@mui/material/Grid';
+
+const Comment = (props) => {
+  const styles = makeStyles({
+    comment: {
+      marginBottom: 30,
+    },
+    commentRight: {
+      border: 'solid 1px #bbb',
+      borderRadius: '10px',
+      overflowWrap: 'break-word',
+      padding: 10,
+    },
+    commentRightFooter: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: 10,
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <Grid container className={classes.comment}>
+      <Grid item xs={2} lg={1}>
+        <div style={{ marginTop: 10 }}>
+          <Owner
+            userId={props.commentAndUser.user.id}
+            userName={props.commentAndUser.user.name}
+            userIconUrl={props.commentAndUser.user.icon_url}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={10} lg={11} className={classes.commentRight}>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(
+              marked(props.commentAndUser.comment.content)
+            ),
+          }}
+          style={{ borderBottom: 'solid 1px #bbb' }}
+        ></div>
+        <div className={classes.commentRightFooter}>
+          <CreatedAt createdAt={props.commentAndUser.comment.created_at} />
+        </div>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Comment;

--- a/frontend/src/components/CommentEdit.js
+++ b/frontend/src/components/CommentEdit.js
@@ -1,0 +1,75 @@
+import React, { useState, useMemo, useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+import Owner from './Owner';
+import SimpleMDE from 'react-simplemde-editor';
+import 'easymde/dist/easymde.min.css';
+import Grid from '@mui/material/Grid';
+import Button from '@mui/material/Button';
+import SendIcon from '@mui/icons-material/Send';
+import CloseIcon from '@mui/icons-material/Close';
+
+const CommentEdit = (props) => {
+  const user = useContext(AuthContext).user;
+  const [markdown, setMarkdown] = useState('');
+  const markdownOption = useMemo(() => {
+    return {
+      toolbar: ['preview'],
+      spellChecker: false,
+    };
+  }, []);
+
+  const editComment = () => {
+    props.editComment(markdown);
+    setMarkdown('');
+    props.handleClose();
+  };
+
+  return (
+    <Grid container>
+      <Grid item xs={2} lg={1}>
+        <div style={{ marginTop: 10 }}>
+          <Owner
+            userId={user.id}
+            userName={user.name}
+            userIconUrl={user.icon_url}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={10} lg={11}>
+        <SimpleMDE
+          value={markdown}
+          onChange={(e) => setMarkdown(e)}
+          options={markdownOption}
+        />
+        <Grid container alignItems='center' justifyContent='center'>
+          {markdown.length > 0 ? (
+            <Button
+              variant='contained'
+              color='primary'
+              style={{ marginRight: 50 }}
+              onClick={editComment}
+            >
+              <SendIcon />
+              更新
+            </Button>
+          ) : (
+            <Button variant='contained' disabled style={{ marginRight: 50 }}>
+              <SendIcon />
+              送信
+            </Button>
+          )}
+          <Button
+            variant='contained'
+            color='secondary'
+            onClick={props.handleClose}
+          >
+            <CloseIcon />
+            キャンセル
+          </Button>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default CommentEdit;

--- a/frontend/src/components/CommentEdit.js
+++ b/frontend/src/components/CommentEdit.js
@@ -55,7 +55,7 @@ const CommentEdit = (props) => {
           ) : (
             <Button variant='contained' disabled style={{ marginRight: 50 }}>
               <SendIcon />
-              送信
+              更新
             </Button>
           )}
           <Button

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -1,30 +1,6 @@
-import Owner from './Owner';
-import CreatedAt from './CreatedAt';
-import marked from 'marked';
-import DOMPurify from 'dompurify';
-import { makeStyles } from '@mui/styles';
-import Grid from '@mui/material/Grid';
+import Comment from './Comment';
 
 const CommentList = (props) => {
-  const styles = makeStyles({
-    comment: {
-      marginBottom: 30,
-    },
-    commentRight: {
-      border: 'solid 1px #bbb',
-      borderRadius: '10px',
-      overflowWrap: 'break-word',
-      padding: 10,
-    },
-    commentRightFooter: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      marginTop: 10,
-    },
-  });
-
-  const classes = styles();
-
   return (
     <div>
       {props.commentsAndUsers.length ? (
@@ -33,30 +9,9 @@ const CommentList = (props) => {
         <h2>コメントはまだありません</h2>
       )}
       {props.commentsAndUsers.map((commentAndUser, i) => (
-        <Grid container key={i} className={classes.comment}>
-          <Grid item xs={2} lg={1}>
-            <div style={{ marginTop: 10 }}>
-              <Owner
-                userId={commentAndUser.user.id}
-                userName={commentAndUser.user.name}
-                userIconUrl={commentAndUser.user.icon_url}
-              />
-            </div>
-          </Grid>
-          <Grid item xs={10} lg={11} className={classes.commentRight}>
-            <div
-              dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(
-                  marked(commentAndUser.comment.content)
-                ),
-              }}
-              style={{ borderBottom: 'solid 1px #bbb' }}
-            ></div>
-            <div className={classes.commentRightFooter}>
-              <CreatedAt createdAt={commentAndUser.comment.created_at} />
-            </div>
-          </Grid>
-        </Grid>
+        <div key={i}>
+          <Comment commentAndUser={commentAndUser} />
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -10,7 +10,12 @@ const CommentList = (props) => {
       )}
       {props.commentsAndUsers.map((commentAndUser, i) => (
         <div key={i}>
-          <Comment commentAndUser={commentAndUser} />
+          <Comment
+            commentAndUser={commentAndUser}
+            deleteComment={() =>
+              props.deleteComment(commentAndUser.comment.id, i)
+            }
+          />
         </div>
       ))}
     </div>

--- a/frontend/src/components/CommentList.js
+++ b/frontend/src/components/CommentList.js
@@ -12,6 +12,9 @@ const CommentList = (props) => {
         <div key={i}>
           <Comment
             commentAndUser={commentAndUser}
+            editComment={(markdown) =>
+              props.editComment(commentAndUser.comment.id, i, markdown)
+            }
             deleteComment={() =>
               props.deleteComment(commentAndUser.comment.id, i)
             }

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -90,6 +90,21 @@ const PostDetail = (props) => {
     axiosAuthClient.delete(`/posts/${id}/likes`);
   };
 
+  const editComment = (commentId, commentIndex, markdown) => {
+    axiosAuthClient
+      .patch(`/posts/${id}/comments/${commentId}`, {
+        comment: { content: markdown },
+      })
+      .then(() => {
+        const newCommentsAndUsers = commentsAndUsers.slice();
+        const commentAndUser = newCommentsAndUsers.splice(commentIndex, 1)[0];
+        commentAndUser.comment.content = markdown;
+        newCommentsAndUsers.splice(commentIndex, 0, commentAndUser);
+        setCommentsAndUsers(newCommentsAndUsers);
+        updateFlashMessage({ successMessage: '更新しました' });
+      });
+  };
+
   const deleteComment = (commentId, commentIndex) => {
     axiosAuthClient.delete(`/posts/${id}/comments/${commentId}`).then(() => {
       const newCommentsAndUsers = commentsAndUsers;
@@ -248,6 +263,7 @@ const PostDetail = (props) => {
         <div style={{ marginTop: 50 }}>
           <CommentList
             commentsAndUsers={commentsAndUsers}
+            editComment={editComment}
             deleteComment={deleteComment}
           />
         </div>

--- a/frontend/src/pages/PostDetail.js
+++ b/frontend/src/pages/PostDetail.js
@@ -90,6 +90,15 @@ const PostDetail = (props) => {
     axiosAuthClient.delete(`/posts/${id}/likes`);
   };
 
+  const deleteComment = (commentId, commentIndex) => {
+    axiosAuthClient.delete(`/posts/${id}/comments/${commentId}`).then(() => {
+      const newCommentsAndUsers = commentsAndUsers;
+      newCommentsAndUsers.splice(commentIndex, 1);
+      setCommentsAndUsers(newCommentsAndUsers);
+      updateFlashMessage({ successMessage: '削除しました' });
+    });
+  };
+
   const styles = makeStyles({
     postDetail: {
       marginBottom: 20,
@@ -237,7 +246,10 @@ const PostDetail = (props) => {
           <CommentForm submitComment={submitComment} />
         </div>
         <div style={{ marginTop: 50 }}>
-          <CommentList commentsAndUsers={commentsAndUsers} />
+          <CommentList
+            commentsAndUsers={commentsAndUsers}
+            deleteComment={deleteComment}
+          />
         </div>
       </Grid>
       <Grid item xs={1} sm={1} md={3} lg={3} />


### PR DESCRIPTION
### 関連issue
#113

### やったこと
- Commentコンポーネントの追加
  CommentListコンポーネントで表示していたコメント部分を切り出した
- PATCH /posts/:post_id/comments/:id と DELETE /posts/:post_id/comments/:id の実装
  `ensure_correct_user`で違うユーザーのコメントに対して編集、削除をできないようにしている
- コメント編集UIを追加
  コメント下の編集するを選択すると、フォームが開く このフォーム(CommentEditコンポーネント)はCommentFormコンポーネントとほぼ同じ
- コメント削除UIを追加
  コメント下の削除するを選択すると、モーダルが表示される

### UI

https://user-images.githubusercontent.com/61813626/148216309-736e8e65-116b-4ce4-a680-d4411e3d9f56.mov

### 参考
- [Array.prototype.splice()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)
