### PR TITLE
コメントの編集で元の文章がフォームに入っているようにした

### DIFF
--- a/frontend/src/components/Comment.js
+++ b/frontend/src/components/Comment.js
@@ -39,6 +39,7 @@ const Comment = (props) => {
         <div style={{ marginBottom: 30 }}>
           <CommentEdit
             editComment={props.editComment}
+            defaultMarkdown={props.commentAndUser.comment.content}
             handleClose={() => setEditOpen(false)}
           />
         </div>

--- a/frontend/src/components/CommentEdit.js
+++ b/frontend/src/components/CommentEdit.js
@@ -10,7 +10,7 @@ import CloseIcon from '@mui/icons-material/Close';
 
 const CommentEdit = (props) => {
   const user = useContext(AuthContext).user;
-  const [markdown, setMarkdown] = useState('');
+  const [markdown, setMarkdown] = useState(props.defaultMarkdown);
   const markdownOption = useMemo(() => {
     return {
       toolbar: ['preview'],


### PR DESCRIPTION
### 関連issue
#113 

### やったこと
#212 でコメントの編集時、元の文章がフォームの中に入っているようにするのを忘れていたので、その修正