### PR TITLE
URLのバリデーションを追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,8 +7,8 @@ class Post < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
   validates :app_name, presence: true, length: { maximum: 50 }
-  validates :app_url, presence: true, length: { maximum: 255 }
-  validates :repo_url, length: { maximum: 255 }
+  validates :app_url, presence: true, length: { maximum: 255 }, format: /\A#{URI::regexp(%w(http https))}\z/
+  validates :repo_url, length: { maximum: 255 }, format: /\A\z|\A#{URI::regexp(%w(http https))}\z/
   validates :description, presence: true, length: { maximum: 10000 }
   validates :like_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,8 +7,8 @@ class Post < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
   validates :app_name, presence: true, length: { maximum: 50 }
-  validates :app_url, presence: true, length: { maximum: 255 }, format: /\Ahttps?:\/\/.+\..+\z/
-  validates :repo_url, length: { maximum: 255 }, format: /\A\z|\Ahttps?:\/\/.+\..+\z/
+  validates :app_url, presence: true, length: { maximum: 255 }, format: %r{\Ahttps?://.+\..+\z}
+  validates :repo_url, length: { maximum: 255 }, format: %r{\A\z|\Ahttps?://.+\..+\z}
   validates :description, presence: true, length: { maximum: 10000 }
   validates :like_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,8 +7,8 @@ class Post < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
   validates :app_name, presence: true, length: { maximum: 50 }
-  validates :app_url, presence: true, length: { maximum: 255 }, format: /\A#{URI::regexp(%w(http https))}\z/
-  validates :repo_url, length: { maximum: 255 }, format: /\A\z|\A#{URI::regexp(%w(http https))}\z/
+  validates :app_url, presence: true, length: { maximum: 255 }, format: /\Ahttps?:\/\/.+\..+\z/
+  validates :repo_url, length: { maximum: 255 }, format: /\A\z|\Ahttps?:\/\/.+\..+\z/
   validates :description, presence: true, length: { maximum: 10000 }
   validates :like_num, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Post, type: :model do
   end
 
   it 'is invalid with an invalid app url' do
-    invalid_urls = %w[httpexample.com httpsexample.com example.com aaahttp://example.com]
+    invalid_urls = %w[http:/ http:// http://example http://example. http://.com ahttp://example.com]
     invalid_urls.each do |invalid_url|
       post = build(:post, app_url: invalid_url)
       expect(post).to be_invalid
@@ -67,7 +67,7 @@ RSpec.describe Post, type: :model do
   end
 
   it 'is invalid with an invalid repo url' do
-    invalid_urls = %w[httpexample.com httpsexample.com example.com aaahttp://example.com]
+    invalid_urls = %w[http:/ http:// http://example http://example. http://.com ahttp://example.com]
     invalid_urls.each do |invalid_url|
       post = build(:post, repo_url: invalid_url)
       expect(post).to be_invalid

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe Post, type: :model do
     expect(post).to be_invalid
   end
 
+  it 'is valid with a valid app url' do
+    valid_urls = %w[http://example.com https://example.com https://sub.example.com]
+    valid_urls.each do |valid_url|
+      post = build(:post, app_url: valid_url)
+      expect(post).to be_valid
+    end
+  end
+
+  it 'is invalid with an invalid app url' do
+    invalid_urls = %w[httpexample.com httpsexample.com example.com aaahttp://example.com]
+    invalid_urls.each do |invalid_url|
+      post = build(:post, app_url: invalid_url)
+      expect(post).to be_invalid
+    end
+  end
+
   it 'is valid with no repo_url' do
     post = build(:post, repo_url: nil)
     expect(post).to be_valid
@@ -40,6 +56,22 @@ RSpec.describe Post, type: :model do
   it 'is invalid with a too long repo_url' do
     post = build(:post, repo_url: 'a' * 256)
     expect(post).to be_invalid
+  end
+
+  it 'is valid with a valid repo url' do
+    valid_urls = %w[http://example.com https://example.com https://sub.example.com]
+    valid_urls.each do |valid_url|
+      post = build(:post, repo_url: valid_url)
+      expect(post).to be_valid
+    end
+  end
+
+  it 'is invalid with an invalid repo url' do
+    invalid_urls = %w[httpexample.com httpsexample.com example.com aaahttp://example.com]
+    invalid_urls.each do |invalid_url|
+      post = build(:post, repo_url: invalid_url)
+      expect(post).to be_invalid
+    end
   end
 
   it 'is invalid with an empty description' do


### PR DESCRIPTION
### 関連issue
#149 

### やったこと
- Postモデルのapp_urlとrepo_urlにバリデーションをかけた
`/\A#{URI::regexp(%w(http https))}\z/`を使うと良いという記事が多かったが、これだと、http:/ や、https://example などの不完全なURLを許してしまうので、自分で正規表現を記述した
- Postモデルのテスト追加
app_urlとrepo_urlのテスト

### 参考
- [Active Record(Railsのモデル) バリデーションまとめ](https://morizyun.github.io/ruby/active-record-validation.html)
- [Rubyで%記法（パーセント記法）を使う](https://qiita.com/mogulla3/items/46bb876391be07921743)
- [singleton method URI.regexp](https://docs.ruby-lang.org/ja/latest/method/URI/s/regexp.html)
- [基本的な正規表現一覧](https://murashun.jp/article/programming/regular-expression.html)
- [Ruby正規表現の使い方](https://www.javadrive.jp/ruby/regex/)